### PR TITLE
Explicitly define W3CCredential type

### DIFF
--- a/.changeset/tired-cycles-tease.md
+++ b/.changeset/tired-cycles-tease.md
@@ -1,0 +1,5 @@
+---
+"@agentcommercekit/vc": patch
+---
+
+Define explicit W3CCredential type to resolve TS compiler issues with inferred return types

--- a/packages/vc/src/types.ts
+++ b/packages/vc/src/types.ts
@@ -1,8 +1,28 @@
-import type {
-  JwtCredentialPayload,
-  Verifiable,
-  W3CCredential
-} from "did-jwt-vc"
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { JwtCredentialPayload, Verifiable } from "did-jwt-vc"
+
+type Extensible<T> = T & Record<string, any>
+
+export interface CredentialStatus {
+  id: string
+  type: string
+}
+
+type W3CCredential = {
+  "@context": string[]
+  id?: string
+  type: string[]
+  issuer: Extensible<{ id: string }>
+  issuanceDate: string
+  expirationDate?: string
+  credentialSubject: Extensible<{
+    id?: string
+  }>
+  credentialStatus?: CredentialStatus
+
+  evidence?: any
+  termsOfUse?: any
+}
 
 export type CredentialSubject = W3CCredential["credentialSubject"]
 export type { JwtCredentialPayload, Verifiable, W3CCredential }

--- a/packages/vc/src/verification/verify-parsed-credential.ts
+++ b/packages/vc/src/verification/verify-parsed-credential.ts
@@ -32,6 +32,7 @@ function isVerifiable(
 ): credential is Verifiable<W3CCredential> {
   return (
     "proof" in credential &&
+    credential.proof !== null &&
     typeof credential.proof === "object" &&
     "type" in credential.proof
   )


### PR DESCRIPTION
For packages using @agentcommercekit/vc, when the inferred return type on a function is W3CCredential, the TS compiler can't properly resolve types because the type depends on types from did-jwt-vc that we don't expose.

Exposing them doesn't make sense, since they're internal implementation details of that package. This PR defines and exports the W3CCredential type explicitly instead.
