### PR TITLE
Add ES256 support 

### DIFF
--- a/.changeset/young-suns-retire.md
+++ b/.changeset/young-suns-retire.md
@@ -1,0 +1,7 @@
+---
+"@agentcommercekit/keys": minor
+"@agentcommercekit/did": minor
+"@agentcommercekit/jwt": minor
+---
+
+Add support for ES256 keys in JWTs

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -8,6 +8,8 @@ words:
   - keypair
   - multibase
   - multicodec
+  - multikey
+  - secp256
   - solana
   - valibot
   - varint

--- a/demos/identity/README.md
+++ b/demos/identity/README.md
@@ -71,13 +71,13 @@ Here is a minimal `did:key` DID Document:
 {
   "@context": [
     "https://www.w3.org/ns/did/v1",
-    "https://w3id.org/security#EcdsaSecp256k1VerificationKey2019"
+    "https://w3id.org/security/jwk/v1"
   ],
   "id": "did:key:zQ3shg46zUAVeEV8pwAYtx4oKj3PvM8vAfpUM1bGKmx3Zibrz",
   "verificationMethod": [
     {
       "id": "did:key:zQ3shg46zUAVeEV8pwAYtx4oKj3PvM8vAfpUM1bGKmx3Zibrz#jwk-1",
-      "type": "EcdsaSecp256k1VerificationKey2019",
+      "type": "JsonWebKey2020",
       "controller": "did:key:zQ3shg46zUAVeEV8pwAYtx4oKj3PvM8vAfpUM1bGKmx3Zibrz",
       "publicKeyJwk": {
         "kty": "EC",
@@ -104,13 +104,13 @@ Here is a more complete `did:web`-based DID Document with those claims:
 {
   "@context": [
     "https://www.w3.org/ns/did/v1",
-    "https://w3id.org/security#EcdsaSecp256k1VerificationKey2019"
+    "https://w3id.org/security/jwk/v1"
   ],
   "id": "did:web:agent.example.com",
   "verificationMethod": [
     {
       "id": "did:web:agent.example.com#jwk-1",
-      "type": "EcdsaSecp256k1VerificationKey2019",
+      "type": "JsonWebKey2020",
       "controller": "did:web:agent.example.com",
       "publicKeyJwk": {
         "kty": "EC",

--- a/docs/demos/demo-identity.mdx
+++ b/docs/demos/demo-identity.mdx
@@ -110,7 +110,7 @@ DID Documents broadcast public keys and essential metadata:
   "verificationMethod": [
     {
       "id": "did:key:zQ3shg46zUAV...#jwk-1",
-      "type": "EcdsaSecp256k1VerificationKey2019",
+      "type": "JsonWebKey2020",
       "controller": "did:key:zQ3shg46zUAV...",
       "publicKeyJwk": { "kty": "EC", "crv": "secp256k1" }
     }
@@ -127,7 +127,7 @@ DID Documents broadcast public keys and essential metadata:
   "verificationMethod": [
     {
       "id": "did:web:agent.example.com#jwk-1",
-      "type": "EcdsaSecp256k1VerificationKey2019",
+      "type": "JsonWebKey2020",
       "controller": "did:web:agent.example.com",
       "publicKeyJwk": { "kty": "EC", "crv": "secp256k1" }
     }

--- a/packages/did/src/methods/did-key.ts
+++ b/packages/did/src/methods/did-key.ts
@@ -22,6 +22,10 @@ export const KEY_CONFIG = {
     multicodecPrefix: 0xe7,
     keyLength: 33
   },
+  secp256r1: {
+    multicodecPrefix: 0x1200,
+    keyLength: 33
+  },
   Ed25519: {
     multicodecPrefix: 0xed,
     keyLength: 32

--- a/packages/did/src/methods/did-web.test.ts
+++ b/packages/did/src/methods/did-web.test.ts
@@ -46,13 +46,13 @@ describe("createDidWebDocument", () => {
     expect(didDocument).toEqual({
       "@context": [
         "https://www.w3.org/ns/did/v1",
-        "https://w3id.org/security#EcdsaSecp256k1VerificationKey2019"
+        "https://w3id.org/security/jwk/v1"
       ],
       id: "did:web:example.com",
       verificationMethod: [
         {
           id: "did:web:example.com#jwk-1",
-          type: "EcdsaSecp256k1VerificationKey2019",
+          type: "JsonWebKey2020",
           controller: "did:web:example.com",
           publicKeyJwk
         }
@@ -81,13 +81,13 @@ describe("createDidWebDocument", () => {
     expect(didDocument).toEqual({
       "@context": [
         "https://www.w3.org/ns/did/v1",
-        "https://w3id.org/security#EcdsaSecp256k1VerificationKey2019"
+        "https://w3id.org/security/multikey/v1"
       ],
       id: "did:web:example.com",
       verificationMethod: [
         {
           id: "did:web:example.com#multibase-1",
-          type: "EcdsaSecp256k1VerificationKey2019",
+          type: "Multikey",
           controller: "did:web:example.com",
           publicKeyMultibase
         }

--- a/packages/jwt/src/create-jwt.ts
+++ b/packages/jwt/src/create-jwt.ts
@@ -12,7 +12,8 @@ export type JwtOptions = JWTOptions
  * Allow alternative names for the algorithm (adds `secp256k1` and `Ed25519`,
  * which map to `ES256K` and `EdDSA` respectively)
  */
-export type JwtHeader = Omit<JWTHeader, "alg"> & {
+export interface JwtHeader extends Omit<JWTHeader, "alg" | "typ"> {
+  typ: "JWT"
   alg: JwtAlgorithm
 }
 

--- a/packages/jwt/src/jwt-algorithm.ts
+++ b/packages/jwt/src/jwt-algorithm.ts
@@ -4,6 +4,7 @@ import { keypairAlgorithms } from "@agentcommercekit/keys"
  * The base algorithms supported by the JWT library
  */
 export const strictJwtAlgorithms = [
+  "ES256",
   "ES256K",
   "ES256K-R",
   "Ed25519",
@@ -36,13 +37,15 @@ export function isJwtAlgorithm(algorithm: unknown): algorithm is JwtAlgorithm {
 /**
  * Resolve the JWT algorithm to the base algorithm
  */
-export function resolveJwtAlgorithm(algorithm: unknown): JwtAlgorithm {
+export function resolveJwtAlgorithm(algorithm: unknown): StrictJwtAlgorithm {
   if (!isJwtAlgorithm(algorithm)) {
     throw new Error(`Unsupported algorithm: '${algorithm}'`)
   }
 
   if (algorithm === "secp256k1") {
     return "ES256K"
+  } else if (algorithm === "secp256r1") {
+    return "ES256"
   } else if (algorithm === "Ed25519") {
     return "EdDSA"
   }

--- a/packages/jwt/src/schemas/valibot.ts
+++ b/packages/jwt/src/schemas/valibot.ts
@@ -1,5 +1,28 @@
 import * as v from "valibot"
+import { jwtAlgorithms } from "../jwt-algorithm"
+import type { JwtHeader, JwtPayload } from "../create-jwt"
 import type { JwtString } from "../jwt-string"
+
+export const jwtPayloadSchema = v.pipe(
+  v.looseObject({
+    iss: v.optional(v.string()),
+    sub: v.optional(v.string()),
+    aud: v.optional(v.union([v.string(), v.array(v.string())])),
+    iat: v.optional(v.number()),
+    nbf: v.optional(v.number()),
+    exp: v.optional(v.number()),
+    rexp: v.optional(v.number())
+  }),
+  v.custom<JwtPayload>(() => true)
+)
+
+export const jwtHeaderSchema = v.pipe(
+  v.looseObject({
+    typ: v.literal("JWT"),
+    alg: v.picklist(jwtAlgorithms)
+  }),
+  v.custom<JwtHeader>(() => true)
+)
 
 export const jwtStringSchema = v.pipe(
   v.string(),

--- a/packages/jwt/src/schemas/zod/v3.ts
+++ b/packages/jwt/src/schemas/zod/v3.ts
@@ -1,5 +1,28 @@
 import { z } from "zod"
+import { jwtAlgorithms } from "../../jwt-algorithm"
 import { isJwtString } from "../../jwt-string"
+import type { JwtHeader, JwtPayload } from "../../create-jwt"
+
+export const jwtPayloadSchema = z
+  .object({
+    iss: z.optional(z.string()),
+    sub: z.optional(z.string()),
+    aud: z.optional(z.union([z.string(), z.array(z.string())])),
+    iat: z.optional(z.number()),
+    nbf: z.optional(z.number()),
+    exp: z.optional(z.number()),
+    rexp: z.optional(z.number())
+  })
+  .passthrough()
+  .refine((val): val is JwtPayload => true)
+
+export const jwtHeaderSchema = z
+  .object({
+    typ: z.literal("JWT"),
+    alg: z.enum(jwtAlgorithms)
+  })
+  .passthrough()
+  .refine((val): val is JwtHeader => true)
 
 export const jwtStringSchema = z
   .string()

--- a/packages/jwt/src/schemas/zod/v4.ts
+++ b/packages/jwt/src/schemas/zod/v4.ts
@@ -1,5 +1,26 @@
 import * as z from "zod/v4"
+import { jwtAlgorithms } from "../../jwt-algorithm"
 import { isJwtString } from "../../jwt-string"
+import type { JwtHeader, JwtPayload } from "../../create-jwt"
+
+export const jwtPayloadSchema = z
+  .looseObject({
+    iss: z.optional(z.string()),
+    sub: z.optional(z.string()),
+    aud: z.optional(z.union([z.string(), z.array(z.string())])),
+    iat: z.optional(z.number()),
+    nbf: z.optional(z.number()),
+    exp: z.optional(z.number()),
+    rexp: z.optional(z.number())
+  })
+  .refine((val): val is JwtPayload => true)
+
+export const jwtHeaderSchema = z
+  .looseObject({
+    typ: z.literal("JWT"),
+    alg: z.enum(jwtAlgorithms)
+  })
+  .refine((val): val is JwtHeader => true)
 
 export const jwtStringSchema = z
   .string()

--- a/packages/jwt/src/signer.ts
+++ b/packages/jwt/src/signer.ts
@@ -1,4 +1,4 @@
-import { ES256KSigner, EdDSASigner } from "did-jwt"
+import { ES256KSigner, ES256Signer, EdDSASigner } from "did-jwt"
 import type { Keypair } from "@agentcommercekit/keys"
 import type { Signer } from "did-jwt"
 
@@ -18,6 +18,8 @@ export function createJwtSigner(keypair: Keypair): JwtSigner {
   switch (keypair.algorithm) {
     case "secp256k1":
       return ES256KSigner(keypair.privateKey)
+    case "secp256r1":
+      return ES256Signer(keypair.privateKey)
     case "Ed25519":
       return EdDSASigner(keypair.privateKey)
     default:

--- a/packages/jwt/src/verify.test.ts
+++ b/packages/jwt/src/verify.test.ts
@@ -51,7 +51,7 @@ describe("verifyJwt()", () => {
       issuer: "did:example:issuer",
       signer: {
         id: "did:example:issuer#key-1",
-        type: "EcdsaSecp256k1VerificationKey2019",
+        type: "Multikey",
         controller: "did:example:issuer",
         publicKeyHex: "02..."
       },
@@ -93,7 +93,7 @@ describe("verifyJwt()", () => {
       issuer: "did:example:issuer",
       signer: {
         id: "did:example:issuer#key-1",
-        type: "EcdsaSecp256k1VerificationKey2019",
+        type: "Multikey",
         controller: "did:example:issuer",
         publicKeyHex: "02..."
       },
@@ -135,7 +135,7 @@ describe("verifyJwt()", () => {
       issuer: "did:example:issuer",
       signer: {
         id: "did:example:issuer#key-1",
-        type: "EcdsaSecp256k1VerificationKey2019",
+        type: "Multikey",
         controller: "did:example:issuer",
         publicKeyHex: "02..."
       },

--- a/packages/keys/package.json
+++ b/packages/keys/package.json
@@ -31,6 +31,10 @@
     "./secp256k1": {
       "types": "./dist/curves/secp256k1.d.ts",
       "default": "./dist/curves/secp256k1.js"
+    },
+    "./secp256r1": {
+      "types": "./dist/curves/secp256r1.d.ts",
+      "default": "./dist/curves/secp256r1.js"
     }
   },
   "main": "./dist/index.js",

--- a/packages/keys/src/curves/secp256r1.test.ts
+++ b/packages/keys/src/curves/secp256r1.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest"
+import { generateKeypair } from "./secp256r1"
+import { hexStringToBytes } from "../encoding/hex"
+
+describe("secp256r1", () => {
+  describe("generateKeypair()", () => {
+    test("generates valid Keypair", async () => {
+      const keypair = await generateKeypair()
+
+      expect(keypair).toBeDefined()
+      expect(keypair.privateKey).toBeInstanceOf(Uint8Array)
+      expect(keypair.publicKey).toBeInstanceOf(Uint8Array)
+      expect(keypair.algorithm).toBe("secp256r1")
+    })
+
+    test("generates a unique `Keypair`s", async () => {
+      const keypair1 = await generateKeypair()
+      const keypair2 = await generateKeypair()
+
+      expect(keypair1.privateKey).not.toEqual(keypair2.privateKey)
+      expect(keypair1.publicKey).not.toEqual(keypair2.publicKey)
+      expect(keypair1.algorithm).toBe("secp256r1")
+      expect(keypair2.algorithm).toBe("secp256r1")
+    })
+  })
+
+  test("generates a Keypair from valid private key", async () => {
+    const privateKeyBytes = hexStringToBytes(
+      "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    )
+
+    const keypair = await generateKeypair(privateKeyBytes)
+
+    expect(keypair).toBeDefined()
+    expect(keypair.privateKey).toEqual(privateKeyBytes)
+    expect(keypair.publicKey).toBeInstanceOf(Uint8Array)
+    expect(keypair.algorithm).toBe("secp256r1")
+  })
+
+  test("throws an error for invalid private key format", async () => {
+    const invalidPrivateKey = new Uint8Array([1, 2, 3]) // Too short for secp256r1
+    await expect(generateKeypair(invalidPrivateKey)).rejects.toThrow()
+  })
+})

--- a/packages/keys/src/curves/secp256r1.ts
+++ b/packages/keys/src/curves/secp256r1.ts
@@ -1,0 +1,34 @@
+import { secp256r1 } from "@noble/curves/p256"
+import type { Keypair } from "../types"
+
+/**
+ * Generate a random private key using the secp256r1 curve
+ */
+function generatePrivateKeyBytes(): Promise<Uint8Array> {
+  return Promise.resolve(secp256r1.utils.randomPrivateKey())
+}
+
+/**
+ * Convert an uncompressed public key to compressed format
+ * @param publicKey - The uncompressed public key (65 bytes)
+ * @returns The compressed public key (33 bytes)
+ */
+export function compressPublicKey(keypair: Keypair): Uint8Array {
+  return secp256r1.getPublicKey(keypair.privateKey, true)
+}
+
+/**
+ * Generate a keypair
+ */
+export async function generateKeypair(
+  privateKeyBytes?: Uint8Array
+): Promise<Keypair> {
+  privateKeyBytes ??= await generatePrivateKeyBytes()
+  const publicKeyBytes = secp256r1.getPublicKey(privateKeyBytes, false)
+
+  return Promise.resolve({
+    publicKey: publicKeyBytes,
+    privateKey: privateKeyBytes,
+    algorithm: "secp256r1"
+  })
+}

--- a/packages/keys/src/encoding/jwk.ts
+++ b/packages/keys/src/encoding/jwk.ts
@@ -11,13 +11,23 @@ export type PublicKeyJwkSecp256k1 = {
   y: string // base64url encoded y-coordinate
 }
 
+export type PublicKeyJwkSecp256r1 = {
+  kty: "EC"
+  crv: "secp256r1"
+  x: string // base64url encoded x-coordinate
+  y: string // base64url encoded y-coordinate
+}
+
 export type PublicKeyJwkEd25519 = {
   kty: "OKP"
   crv: "Ed25519"
   x: string // base64url encoded x-coordinate
 }
 
-export type PublicKeyJwk = PublicKeyJwkSecp256k1 | PublicKeyJwkEd25519
+export type PublicKeyJwk =
+  | PublicKeyJwkSecp256k1
+  | PublicKeyJwkSecp256r1
+  | PublicKeyJwkEd25519
 
 /**
  * JWK-encoding for private keys
@@ -26,16 +36,17 @@ export type PrivateKeyJwk = PublicKeyJwk & {
   d: string // base64url encoded private key
 }
 
-export function isPublicKeyJwkSecp256k1(
-  jwk: unknown
-): jwk is PublicKeyJwkSecp256k1 {
+function isPublicKeyJwkSecp256(
+  jwk: unknown,
+  crv: "secp256k1" | "secp256r1"
+): jwk is PublicKeyJwkSecp256k1 | PublicKeyJwkSecp256r1 {
   if (typeof jwk !== "object" || jwk === null) {
     return false
   }
 
   const obj = jwk as Record<string, unknown>
 
-  if (obj.kty !== "EC" || obj.crv !== "secp256k1") {
+  if (obj.kty !== "EC" || obj.crv !== crv) {
     return false
   }
 
@@ -48,6 +59,18 @@ export function isPublicKeyJwkSecp256k1(
   }
 
   return true
+}
+
+export function isPublicKeyJwkSecp256k1(
+  jwk: unknown
+): jwk is PublicKeyJwkSecp256k1 {
+  return isPublicKeyJwkSecp256(jwk, "secp256k1")
+}
+
+export function isPublicKeyJwkSecp256r1(
+  jwk: unknown
+): jwk is PublicKeyJwkSecp256k1 {
+  return isPublicKeyJwkSecp256(jwk, "secp256r1")
 }
 
 export function isPublicKeyJwkEd25519(

--- a/packages/keys/src/keypair.ts
+++ b/packages/keys/src/keypair.ts
@@ -1,5 +1,6 @@
 import { generateKeypair as ed25519 } from "./curves/ed25519"
 import { generateKeypair as secp256k1 } from "./curves/secp256k1"
+import { generateKeypair as secp256r1 } from "./curves/secp256r1"
 import { base64urlToBytes, bytesToBase64url } from "./encoding/base64"
 import { bytesToJwk, jwkToBytes } from "./encoding/jwk"
 import type { PrivateKeyJwk } from "./encoding/jwk"
@@ -18,6 +19,10 @@ export async function generateKeypair(
 ): Promise<Keypair> {
   if (algorithm === "secp256k1") {
     return secp256k1(privateKeyBytes)
+  }
+
+  if (algorithm === "secp256r1") {
+    return secp256r1(privateKeyBytes)
   }
 
   return ed25519(privateKeyBytes)

--- a/packages/keys/src/types.ts
+++ b/packages/keys/src/types.ts
@@ -1,4 +1,4 @@
-export const keypairAlgorithms = ["secp256k1", "Ed25519"] as const
+export const keypairAlgorithms = ["secp256k1", "secp256r1", "Ed25519"] as const
 export type KeypairAlgorithm = (typeof keypairAlgorithms)[number]
 
 export interface Keypair {


### PR DESCRIPTION
- Add support for secp256r1 (P-256) elliptic curve
- Simplifies the DID `verificationMethod` types to be either `Multikey` (for Multibase keys) or `JsonWebKey2020` (for JWK keys).
- Adds schemas for our jwt payload and jwt headers
