### PR TITLE
Improve JWK encoding/decoding, PublicKey methods

### DIFF
--- a/.changeset/silver-parks-juggle.md
+++ b/.changeset/silver-parks-juggle.md
@@ -1,0 +1,10 @@
+---
+"agentcommercekit": minor
+"@agentcommercekit/ack-pay": minor
+"@agentcommercekit/keys": minor
+"@agentcommercekit/did": minor
+"@agentcommercekit/jwt": minor
+"@agentcommercekit/vc": minor
+---
+
+Improve JWK encoding/decoding and public key methods

--- a/demos/skyfire-kya/src/jwk-keys.ts
+++ b/demos/skyfire-kya/src/jwk-keys.ts
@@ -1,4 +1,4 @@
-import { bytesToJwk, generateKeypair } from "agentcommercekit"
+import { generateKeypair, publicKeyBytesToJwk } from "agentcommercekit"
 
 /**
  * Generate a keypair and an associated JWKS
@@ -8,7 +8,7 @@ import { bytesToJwk, generateKeypair } from "agentcommercekit"
 export async function generateJwks() {
   const keypair = await generateKeypair("secp256r1")
   const publicKeyJwk = {
-    ...bytesToJwk(keypair.publicKey, "secp256r1"),
+    ...publicKeyBytesToJwk(keypair.publicKey, "secp256r1"),
     crv: "P-256",
     use: "sig",
     kid: "skyfire-key-1",

--- a/packages/did/src/methods/did-key.ts
+++ b/packages/did/src/methods/did-key.ts
@@ -1,4 +1,4 @@
-import { getCompressedPublicKey } from "@agentcommercekit/keys"
+import { getPublicKeyFromPrivateKey } from "@agentcommercekit/keys"
 import { bytesToMultibase } from "@agentcommercekit/keys/encoding"
 import * as varint from "varint"
 import type { Keypair } from "@agentcommercekit/keys"
@@ -57,7 +57,11 @@ export function isDidKeyUri(did: unknown): did is DidKeyUri {
  */
 export function createDidKeyUri(keypair: Keypair): DidKeyUri {
   const keyConfig = KEY_CONFIG[keypair.curve]
-  const publicKey = getCompressedPublicKey(keypair)
+  const publicKey = getPublicKeyFromPrivateKey(
+    keypair.privateKey,
+    keypair.curve,
+    true
+  )
 
   if (publicKey.length !== keyConfig.keyLength) {
     throw new Error(

--- a/packages/did/src/methods/did-web.test.ts
+++ b/packages/did/src/methods/did-web.test.ts
@@ -1,8 +1,8 @@
 import { generateKeypair } from "@agentcommercekit/keys"
 import {
   bytesToHexString,
-  bytesToJwk,
-  bytesToMultibase
+  bytesToMultibase,
+  publicKeyBytesToJwk
 } from "@agentcommercekit/keys/encoding"
 import { describe, expect, it } from "vitest"
 import { createDidWebDocument, createDidWebUri } from "./did-web"
@@ -30,7 +30,7 @@ describe("createDidWeb", () => {
 describe("createDidWebDocument", () => {
   it("generates a valid DidUri and DidDocument with JWK", async () => {
     const keypair = await generateKeypair("secp256k1")
-    const publicKeyJwk = bytesToJwk(keypair.publicKey, keypair.curve)
+    const publicKeyJwk = publicKeyBytesToJwk(keypair.publicKey, keypair.curve)
 
     const { did, didDocument } = createDidWebDocument({
       publicKey: {

--- a/packages/keys/README.md
+++ b/packages/keys/README.md
@@ -43,7 +43,6 @@ const base58PublicKey = encodePublicKeyFromKeypair("base58", keypair)
 ### Public Key Formatting
 
 - `encodePublicKeyFromKeypair<T extends PublicKeyEncoding>(encoding: T, keypair: Keypair): PublicKeyTypeMap[T]`
-- `getCompressedPublicKey(keypair: Keypair): Uint8Array`
 
 ### Additional Exports
 

--- a/packages/keys/src/curves/ed25519.ts
+++ b/packages/keys/src/curves/ed25519.ts
@@ -4,8 +4,15 @@ import type { Keypair } from "../keypair"
 /**
  * Generate a random private key using the Ed25519 curve
  */
-function generatePrivateKeyBytes(): Promise<Uint8Array> {
+export function generatePrivateKey(): Promise<Uint8Array> {
   return Promise.resolve(ed25519.utils.randomPrivateKey())
+}
+
+/**
+ * Get the public key from a private key
+ */
+export function getPublicKeyBytes(privateKeyBytes: Uint8Array): Uint8Array {
+  return ed25519.getPublicKey(privateKeyBytes)
 }
 
 /**
@@ -14,8 +21,8 @@ function generatePrivateKeyBytes(): Promise<Uint8Array> {
 export async function generateKeypair(
   privateKeyBytes?: Uint8Array
 ): Promise<Keypair> {
-  privateKeyBytes ??= await generatePrivateKeyBytes()
-  const publicKeyBytes = ed25519.getPublicKey(privateKeyBytes)
+  privateKeyBytes ??= await generatePrivateKey()
+  const publicKeyBytes = getPublicKeyBytes(privateKeyBytes)
 
   return Promise.resolve({
     publicKey: publicKeyBytes,

--- a/packages/keys/src/curves/secp256k1.ts
+++ b/packages/keys/src/curves/secp256k1.ts
@@ -4,17 +4,18 @@ import type { Keypair } from "../keypair"
 /**
  * Generate a random private key using the secp256k1 curve
  */
-function generatePrivateKeyBytes(): Promise<Uint8Array> {
+export function generatePrivateKey(): Promise<Uint8Array> {
   return Promise.resolve(secp256k1.utils.randomPrivateKey())
 }
 
 /**
- * Convert an uncompressed public key to compressed format
- * @param publicKey - The uncompressed public key (65 bytes)
- * @returns The compressed public key (33 bytes)
+ * Get the public key from a private key
  */
-export function compressPublicKey(keypair: Keypair): Uint8Array {
-  return secp256k1.getPublicKey(keypair.privateKey, true)
+export function getPublicKeyBytes(
+  privateKeyBytes: Uint8Array,
+  compressed = false
+): Uint8Array {
+  return secp256k1.getPublicKey(privateKeyBytes, compressed)
 }
 
 /**
@@ -23,8 +24,8 @@ export function compressPublicKey(keypair: Keypair): Uint8Array {
 export async function generateKeypair(
   privateKeyBytes?: Uint8Array
 ): Promise<Keypair> {
-  privateKeyBytes ??= await generatePrivateKeyBytes()
-  const publicKeyBytes = secp256k1.getPublicKey(privateKeyBytes, false)
+  privateKeyBytes ??= await generatePrivateKey()
+  const publicKeyBytes = getPublicKeyBytes(privateKeyBytes, false)
 
   return Promise.resolve({
     publicKey: publicKeyBytes,

--- a/packages/keys/src/curves/secp256r1.ts
+++ b/packages/keys/src/curves/secp256r1.ts
@@ -4,17 +4,18 @@ import type { Keypair } from "../keypair"
 /**
  * Generate a random private key using the secp256r1 curve
  */
-function generatePrivateKeyBytes(): Promise<Uint8Array> {
+export function generatePrivateKey(): Promise<Uint8Array> {
   return Promise.resolve(secp256r1.utils.randomPrivateKey())
 }
 
 /**
- * Convert an uncompressed public key to compressed format
- * @param publicKey - The uncompressed public key (65 bytes)
- * @returns The compressed public key (33 bytes)
+ * Get the public key from a private key
  */
-export function compressPublicKey(keypair: Keypair): Uint8Array {
-  return secp256r1.getPublicKey(keypair.privateKey, true)
+export function getPublicKeyBytes(
+  privateKeyBytes: Uint8Array,
+  compressed = false
+): Uint8Array {
+  return secp256r1.getPublicKey(privateKeyBytes, compressed)
 }
 
 /**
@@ -23,8 +24,8 @@ export function compressPublicKey(keypair: Keypair): Uint8Array {
 export async function generateKeypair(
   privateKeyBytes?: Uint8Array
 ): Promise<Keypair> {
-  privateKeyBytes ??= await generatePrivateKeyBytes()
-  const publicKeyBytes = secp256r1.getPublicKey(privateKeyBytes, false)
+  privateKeyBytes ??= await generatePrivateKey()
+  const publicKeyBytes = getPublicKeyBytes(privateKeyBytes, false)
 
   return Promise.resolve({
     publicKey: publicKeyBytes,

--- a/packages/keys/src/encoding/jwk.test.ts
+++ b/packages/keys/src/encoding/jwk.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "vitest"
 import { bytesToBase64url, isBase64url } from "./base64"
-import { bytesToJwk, isPrivateKeyJwk, isPublicKeyJwk, jwkToBytes } from "./jwk"
+import {
+  isPrivateKeyJwk,
+  isPublicKeyJwk,
+  publicKeyBytesToJwk,
+  publicKeyJwkToBytes
+} from "./jwk"
 import type { PublicKeyJwkEd25519, PublicKeyJwkSecp256k1 } from "./jwk"
 
 describe("JWK encoding", () => {
@@ -15,9 +20,12 @@ describe("JWK encoding", () => {
   const base64String = bytesToBase64url(Ed25519Bytes) // base64url of 32 bytes of 1s
   const base64String2 = bytesToBase64url(secp256k1Bytes.slice(33)) // base64url of 32 bytes of 2s
 
-  describe("bytesToJwk", () => {
+  describe("publicKeyBytesToJwk", () => {
     test("converts Ed25519 public key to JWK", () => {
-      const jwk = bytesToJwk(Ed25519Bytes, "Ed25519") as PublicKeyJwkEd25519
+      const jwk = publicKeyBytesToJwk(
+        Ed25519Bytes,
+        "Ed25519"
+      ) as PublicKeyJwkEd25519
       expect(jwk).toEqual({
         kty: "OKP",
         crv: "Ed25519",
@@ -27,7 +35,7 @@ describe("JWK encoding", () => {
     })
 
     test("converts secp256k1 public key to JWK", () => {
-      const jwk = bytesToJwk(
+      const jwk = publicKeyBytesToJwk(
         secp256k1Bytes,
         "secp256k1"
       ) as PublicKeyJwkSecp256k1
@@ -42,14 +50,14 @@ describe("JWK encoding", () => {
     })
   })
 
-  describe("jwkToBytes", () => {
+  describe("publicKeyJwkToBytes", () => {
     test("converts Ed25519 JWK to bytes", () => {
       const jwk: PublicKeyJwkEd25519 = {
         kty: "OKP",
         crv: "Ed25519",
         x: base64String
       }
-      const bytes = jwkToBytes(jwk)
+      const bytes = publicKeyJwkToBytes(jwk)
       expect(bytes).toEqual(Ed25519Bytes)
     })
 
@@ -60,7 +68,7 @@ describe("JWK encoding", () => {
         x: base64String,
         y: base64String2
       }
-      const bytes = jwkToBytes(jwk)
+      const bytes = publicKeyJwkToBytes(jwk)
       expect(bytes).toEqual(secp256k1Bytes)
     })
   })
@@ -165,17 +173,20 @@ describe("JWK encoding", () => {
 
   describe("roundtrip", () => {
     test("roundtrips Ed25519 public key through JWK", () => {
-      const jwk = bytesToJwk(Ed25519Bytes, "Ed25519") as PublicKeyJwkEd25519
-      const bytes = jwkToBytes(jwk)
+      const jwk = publicKeyBytesToJwk(
+        Ed25519Bytes,
+        "Ed25519"
+      ) as PublicKeyJwkEd25519
+      const bytes = publicKeyJwkToBytes(jwk)
       expect(bytes).toEqual(Ed25519Bytes)
     })
 
     test("roundtrips secp256k1 public key through JWK", () => {
-      const jwk = bytesToJwk(
+      const jwk = publicKeyBytesToJwk(
         secp256k1Bytes,
         "secp256k1"
       ) as PublicKeyJwkSecp256k1
-      const bytes = jwkToBytes(jwk)
+      const bytes = publicKeyJwkToBytes(jwk)
       expect(bytes).toEqual(secp256k1Bytes)
     })
   })

--- a/packages/keys/src/encoding/jwk.ts
+++ b/packages/keys/src/encoding/jwk.ts
@@ -1,4 +1,5 @@
 import { base64urlToBytes, bytesToBase64url } from "./base64"
+import { getPublicKeyFromPrivateKey } from "../public-key"
 import type { KeyCurve } from "../key-curves"
 
 /**
@@ -123,7 +124,10 @@ export function isPrivateKeyJwk(jwk: unknown): jwk is PrivateKeyJwk {
 /**
  * Convert public key bytes to a JWK format
  */
-export function bytesToJwk(bytes: Uint8Array, curve: KeyCurve): PublicKeyJwk {
+export function publicKeyBytesToJwk(
+  bytes: Uint8Array,
+  curve: KeyCurve
+): PublicKeyJwk {
   switch (curve) {
     case "Ed25519":
       return {
@@ -154,10 +158,24 @@ export function bytesToJwk(bytes: Uint8Array, curve: KeyCurve): PublicKeyJwk {
   }
 }
 
+export function privateKeyBytesToJwk(
+  bytes: Uint8Array,
+  curve: KeyCurve
+): PrivateKeyJwk {
+  const publicKeyBytes = getPublicKeyFromPrivateKey(bytes, curve)
+  const publicKeyJwk = publicKeyBytesToJwk(publicKeyBytes, curve)
+
+  return {
+    ...publicKeyJwk,
+    d: bytesToBase64url(bytes)
+  }
+}
+
 /**
+ * }
  * Convert a JWK to public key bytes
  */
-export function jwkToBytes(jwk: PublicKeyJwk): Uint8Array {
+export function publicKeyJwkToBytes(jwk: PublicKeyJwk): Uint8Array {
   const xBytes = base64urlToBytes(jwk.x)
 
   // For secp256k1 and secp256r1, we need to reconstruct the full public key
@@ -175,3 +193,13 @@ export function jwkToBytes(jwk: PublicKeyJwk): Uint8Array {
   // For Ed25519, the x field is the complete public key
   return xBytes
 }
+
+/**
+ * @deprecated Use `publicKeyBytesToJwk` instead
+ */
+export const bytesToJwk = publicKeyBytesToJwk
+
+/**
+ * @deprecated Use `publicKeyJwkToBytes` instead
+ */
+export const jwkToBytes = publicKeyJwkToBytes


### PR DESCRIPTION
This makes the following changes:

- Renames `bytesToJwk` and `jwkToBytes` to `publicKeyBytesToJwk` and `jwkToPublicKeyBytes` be clear that it is exclusively for public key JWKs
- Adds similar methods for Private Key JWKs
- Adds methods to more easily access Public Keys from a Private Key alone, allowing for easier JWK creation directly from a private key.