### PR TITLE
Update privateKeyBytes generation to be sync

### DIFF
--- a/.changeset/silly-humans-worry.md
+++ b/.changeset/silly-humans-worry.md
@@ -1,0 +1,5 @@
+---
+"@agentcommercekit/keys": patch
+---
+
+Update private key generation to by sync

--- a/demos/payments/src/utils/ensure-private-keys.ts
+++ b/demos/payments/src/utils/ensure-private-keys.ts
@@ -10,7 +10,7 @@ export async function ensurePrivateKey(name: string) {
   }
 
   log(colors.dim(`Generating ${name}...`))
-  const newPrivateKeyHex = await generatePrivateKeyHex()
+  const newPrivateKeyHex = generatePrivateKeyHex()
   await updateEnvFile({ [name]: newPrivateKeyHex }, envFilePath)
   return newPrivateKeyHex
 }

--- a/demos/payments/src/utils/keypair-info.ts
+++ b/demos/payments/src/utils/keypair-info.ts
@@ -3,6 +3,7 @@ import {
   createDidPkhUri,
   createJwtSigner,
   generateKeypair,
+  generatePrivateKeyBytes,
   hexStringToBytes
 } from "agentcommercekit"
 import { privateKeyToAccount } from "viem/accounts"
@@ -56,7 +57,7 @@ export async function getKeypairInfo(
 /**
  * Generates a new private key, and returns it in hex string format.
  */
-export async function generatePrivateKeyHex() {
-  const { privateKey } = await generateKeypair("secp256k1")
+export function generatePrivateKeyHex() {
+  const privateKey = generatePrivateKeyBytes("secp256k1")
   return `0x${bytesToHexString(privateKey)}`
 }

--- a/packages/keys/src/curves/ed25519.ts
+++ b/packages/keys/src/curves/ed25519.ts
@@ -4,8 +4,8 @@ import type { Keypair } from "../keypair"
 /**
  * Generate a random private key using the Ed25519 curve
  */
-export function generatePrivateKey(): Promise<Uint8Array> {
-  return Promise.resolve(ed25519.utils.randomPrivateKey())
+export function generatePrivateKeyBytes(): Uint8Array {
+  return ed25519.utils.randomPrivateKey()
 }
 
 /**
@@ -19,9 +19,8 @@ export function getPublicKeyBytes(privateKeyBytes: Uint8Array): Uint8Array {
  * Generate a keypair
  */
 export async function generateKeypair(
-  privateKeyBytes?: Uint8Array
+  privateKeyBytes = generatePrivateKeyBytes()
 ): Promise<Keypair> {
-  privateKeyBytes ??= await generatePrivateKey()
   const publicKeyBytes = getPublicKeyBytes(privateKeyBytes)
 
   return Promise.resolve({

--- a/packages/keys/src/curves/secp256k1.ts
+++ b/packages/keys/src/curves/secp256k1.ts
@@ -4,8 +4,8 @@ import type { Keypair } from "../keypair"
 /**
  * Generate a random private key using the secp256k1 curve
  */
-export function generatePrivateKey(): Promise<Uint8Array> {
-  return Promise.resolve(secp256k1.utils.randomPrivateKey())
+export function generatePrivateKeyBytes(): Uint8Array {
+  return secp256k1.utils.randomPrivateKey()
 }
 
 /**
@@ -22,9 +22,8 @@ export function getPublicKeyBytes(
  * Generate a keypair
  */
 export async function generateKeypair(
-  privateKeyBytes?: Uint8Array
+  privateKeyBytes = generatePrivateKeyBytes()
 ): Promise<Keypair> {
-  privateKeyBytes ??= await generatePrivateKey()
   const publicKeyBytes = getPublicKeyBytes(privateKeyBytes, false)
 
   return Promise.resolve({

--- a/packages/keys/src/curves/secp256r1.ts
+++ b/packages/keys/src/curves/secp256r1.ts
@@ -4,8 +4,8 @@ import type { Keypair } from "../keypair"
 /**
  * Generate a random private key using the secp256r1 curve
  */
-export function generatePrivateKey(): Promise<Uint8Array> {
-  return Promise.resolve(secp256r1.utils.randomPrivateKey())
+export function generatePrivateKeyBytes(): Uint8Array {
+  return secp256r1.utils.randomPrivateKey()
 }
 
 /**
@@ -22,9 +22,8 @@ export function getPublicKeyBytes(
  * Generate a keypair
  */
 export async function generateKeypair(
-  privateKeyBytes?: Uint8Array
+  privateKeyBytes = generatePrivateKeyBytes()
 ): Promise<Keypair> {
-  privateKeyBytes ??= await generatePrivateKey()
   const publicKeyBytes = getPublicKeyBytes(privateKeyBytes, false)
 
   return Promise.resolve({

--- a/packages/keys/src/keypair.ts
+++ b/packages/keys/src/keypair.ts
@@ -12,19 +12,16 @@ export interface Keypair {
   curve: KeyCurve
 }
 
-export async function keypairFromPrivateKeyBytes(
-  curve: KeyCurve,
-  privateKeyBytes: Uint8Array
-): Promise<Keypair> {
+export function generatePrivateKeyBytes(curve: KeyCurve): Uint8Array {
   if (curve === "secp256k1") {
-    return secp256k1.generateKeypair(privateKeyBytes)
+    return secp256k1.generatePrivateKeyBytes()
   }
 
   if (curve === "secp256r1") {
-    return secp256r1.generateKeypair(privateKeyBytes)
+    return secp256r1.generatePrivateKeyBytes()
   }
 
-  return ed25519.generateKeypair(privateKeyBytes)
+  return ed25519.generatePrivateKeyBytes()
 }
 
 /**
@@ -39,17 +36,14 @@ export async function generateKeypair(
   privateKeyBytes?: Uint8Array
 ): Promise<Keypair> {
   if (curve === "secp256k1") {
-    privateKeyBytes ??= await secp256k1.generatePrivateKey()
-    return keypairFromPrivateKeyBytes(curve, privateKeyBytes)
+    return secp256k1.generateKeypair(privateKeyBytes)
   }
 
   if (curve === "secp256r1") {
-    privateKeyBytes ??= await secp256r1.generatePrivateKey()
-    return keypairFromPrivateKeyBytes(curve, privateKeyBytes)
+    return secp256r1.generateKeypair(privateKeyBytes)
   }
 
-  privateKeyBytes ??= await ed25519.generatePrivateKey()
-  return keypairFromPrivateKeyBytes(curve, privateKeyBytes)
+  return ed25519.generateKeypair(privateKeyBytes)
 }
 
 /**


### PR DESCRIPTION
Generating random bytes is sync in this change, but the keypair generation methods are all still wrapped in async methods for future-proofing.