### PR TITLE
allow providing payment request value as a string

### DIFF
--- a/.changeset/tender-bags-give.md
+++ b/.changeset/tender-bags-give.md
@@ -1,0 +1,6 @@
+---
+"agentcommercekit": patch
+"@agentcommercekit/ack-pay": patch
+---
+
+Allow providing string value for payment option amount.

--- a/demos/e2e/src/agent.ts
+++ b/demos/e2e/src/agent.ts
@@ -212,7 +212,7 @@ ${colors.bold(otherAgent.did)}
           paymentOptions: [
             {
               id: crypto.randomUUID(),
-              amount: 500,
+              amount: BigInt(500).toString(),
               decimals: 2,
               currency: "USD",
               recipient: this.walletDid

--- a/demos/payments/src/server.ts
+++ b/demos/payments/src/server.ts
@@ -61,7 +61,7 @@ app.get("/", async (c): Promise<TypedResponse<{ message: string }>> => {
         // USDC on Base
         {
           id: "usdc-base-sepolia",
-          amount: 50000, // 5 cents in USDC subunits
+          amount: BigInt(50000).toString(), // 5 cents in USDC subunits
           decimals: 6,
           currency: "USDC",
           recipient: serverIdentity.crypto.address, // This could be a did:pkh

--- a/packages/ack-pay/README.md
+++ b/packages/ack-pay/README.md
@@ -34,9 +34,9 @@ const paymentRequest = {
   paymentOptions: [
     {
       id: "option-1",
-      amount: 1000,
-      decimals: 2,
-      currency: "USD",
+      amount: new BigInt(100_000_000).toString(), // 100 USDC
+      decimals: 6,
+      currency: "USDC",
       recipient: "did:web:payment.example.com",
       paymentService: "https://pay.example.com"
     }

--- a/packages/ack-pay/src/payment-request.test.ts
+++ b/packages/ack-pay/src/payment-request.test.ts
@@ -8,7 +8,7 @@ describe("isPaymentRequest", () => {
     paymentOptions: [
       {
         id: "test-payment-option-id",
-        amount: 100,
+        amount: BigInt(100).toString(),
         decimals: 2,
         currency: "USD",
         recipient: "did:example:recipient"

--- a/packages/ack-pay/src/schemas/valibot.ts
+++ b/packages/ack-pay/src/schemas/valibot.ts
@@ -5,7 +5,7 @@ const urlOrDidUri = v.union([v.pipe(v.string(), v.url()), didUriSchema])
 
 export const paymentOptionSchema = v.object({
   id: v.string(),
-  amount: v.pipe(v.number(), v.integer(), v.gtValue(0)),
+  amount: v.union([v.pipe(v.number(), v.integer(), v.gtValue(0)), v.string()]),
   decimals: v.pipe(v.number(), v.integer(), v.toMinValue(0)),
   currency: v.string(),
   recipient: v.string(),

--- a/packages/ack-pay/src/schemas/zod/v3.ts
+++ b/packages/ack-pay/src/schemas/zod/v3.ts
@@ -5,7 +5,7 @@ const urlOrDidUri = z.union([z.string().url(), didUriSchema])
 
 export const paymentOptionSchema = z.object({
   id: z.string(),
-  amount: z.number().int().positive(),
+  amount: z.union([z.number().int().positive(), z.string()]),
   decimals: z.number().int().nonnegative(),
   currency: z.string(),
   recipient: z.string(),

--- a/packages/ack-pay/src/schemas/zod/v4.ts
+++ b/packages/ack-pay/src/schemas/zod/v4.ts
@@ -5,7 +5,7 @@ const urlOrDidUri = z.union([z.url(), didUriSchema])
 
 export const paymentOptionSchema = z.object({
   id: z.string(),
-  amount: z.number().int().positive(),
+  amount: z.union([z.number().int().positive(), z.string()]),
   decimals: z.number().int().nonnegative(),
   currency: z.string(),
   recipient: z.string(),

--- a/packages/agentcommercekit/README.md
+++ b/packages/agentcommercekit/README.md
@@ -125,9 +125,9 @@ const paymentRequest = {
   paymentOptions: [
     {
       id: "option-1",
-      amount: 1000,
-      decimals: 2,
-      currency: "USD",
+      amount: BigInt(100_000_000).toString(), // 100 USDC
+      decimals: 6,
+      currency: "USDC",
       recipient: "did:web:payment.example.com",
       paymentService: "https://pay.example.com"
     }


### PR DESCRIPTION
In practice, when specifying monetary values as minor units, it is safer to represent amounts as strings to not lose precision. This updates the `paymentRequest.paymentOption.amount` type to be `string | number`. Users of the sdk can still specify the value as a number if they prefer.