### PR TITLE
fix(demo): resolve type error in skyfire-kya token creation

### DIFF
--- a/demos/skyfire-kya/src/kya-token.ts
+++ b/demos/skyfire-kya/src/kya-token.ts
@@ -52,8 +52,7 @@ export async function createMockSkyfireKyaToken(
       expiresIn: 3600,
     },
     {
-      // @ts-expect-error - TODO: fix this
-      typ: "kya+JWT",
+      typ: "kya+JWT" as "JWT",
       alg: "ES256",
     },
   )


### PR DESCRIPTION
## Summary
- Replace `@ts-expect-error` suppression with an explicit type assertion for the non-standard `"kya+JWT"` typ header

The Skyfire KYA spec uses a custom media type (`kya+JWT`) per RFC 7515 structured syntax suffixes. The assertion documents this intent rather than silencing the type error with a TODO comment.

## Test plan
- [x] Demo compiles without type errors
- [x] `pnpm demo:skyfire-kya` runs successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved TypeScript type handling by replacing error suppression with an explicit type assertion in token creation logic. No functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**AI Disclosure:** This PR was developed with assistance from Claude Code (Claude Opus).