### PR TITLE
fix(caip): add input validation to createCaip10AccountId

### DIFF
--- a/packages/caip/src/caips/caip-10.test.ts
+++ b/packages/caip/src/caips/caip-10.test.ts
@@ -20,4 +20,19 @@ describe("createCaip10AccountId", () => {
       "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:FNoGHiv7DKPLXHfuhiEWpJ8qYitawGkuaYwfYkuvFk1P",
     )
   })
+
+  it("throws for invalid chain ID", () => {
+    expect(() =>
+      createCaip10AccountId(
+        "bad" as any,
+        "0x1234567890123456789012345678901234567890",
+      ),
+    ).toThrow("Invalid CAIP-2 chain ID")
+  })
+
+  it("throws for invalid account address", () => {
+    expect(() => createCaip10AccountId("eip155:1", "")).toThrow(
+      "Invalid CAIP-10 account address",
+    )
+  })
 })

--- a/packages/caip/src/caips/caip-10.ts
+++ b/packages/caip/src/caips/caip-10.ts
@@ -38,10 +38,10 @@ export function createCaip10AccountId(
   chainId: Caip2ChainId,
   address: string,
 ): Caip10AccountId {
-  if (!caip2ChainIdRegex.test(chainId)) {
+  if (typeof chainId !== "string" || !caip2ChainIdRegex.test(chainId)) {
     throw new Error(`Invalid CAIP-2 chain ID: ${chainId}`)
   }
-  if (!caip10AccountAddressRegex.test(address)) {
+  if (typeof address !== "string" || !caip10AccountAddressRegex.test(address)) {
     throw new Error(`Invalid CAIP-10 account address: ${address}`)
   }
   return `${chainId}:${address}`

--- a/packages/caip/src/caips/caip-10.ts
+++ b/packages/caip/src/caips/caip-10.ts
@@ -1,5 +1,6 @@
 import {
   caip2ChainIdPattern,
+  caip2ChainIdRegex,
   type Caip2ChainId,
   type Caip2ChainIdParts,
 } from "./caip-2"
@@ -37,6 +38,12 @@ export function createCaip10AccountId(
   chainId: Caip2ChainId,
   address: string,
 ): Caip10AccountId {
+  if (!caip2ChainIdRegex.test(chainId)) {
+    throw new Error(`Invalid CAIP-2 chain ID: ${chainId}`)
+  }
+  if (!caip10AccountAddressRegex.test(address)) {
+    throw new Error(`Invalid CAIP-10 account address: ${address}`)
+  }
   return `${chainId}:${address}`
 }
 


### PR DESCRIPTION
## Summary
- Validate `chainId` against `caip2ChainIdRegex` and `address` against `caip10AccountAddressRegex` before creating the account ID
- Add test cases for invalid inputs

`createCaip10AccountId` previously performed no validation, allowing malformed chain IDs and addresses to propagate silently. The regex patterns were already defined in the module but not being used. This brings the function in line with `caip10Parts()`, which already validates its input.

## Test plan
- [x] Existing CAIP tests pass
- [x] New tests verify rejection of invalid chain IDs and addresses

---

**AI Disclosure:** This PR was developed with assistance from Claude Code (Claude Opus).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when creating CAIP-10 account IDs so invalid chain identifiers and empty/invalid account addresses are rejected with clearer error responses.
* **Tests**
  * Added test coverage for the new validation and expected failure cases to ensure reliable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->