### PR TITLE
feat: add MCP server for ACK-ID and ACK-Pay operations

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -602,6 +602,22 @@ importers:
         specifier: 1.7.0
         version: 1.7.0
 
+  tools/mcp-server:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 1.21.2
+        version: 1.21.2
+      agentcommercekit:
+        specifier: workspace:*
+        version: link:../../packages/agentcommercekit
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.4
+    devDependencies:
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+
   tools/typescript-config: {}
 
 packages:
@@ -1692,6 +1708,15 @@ packages:
 
   '@mintlify/validation@0.1.606':
     resolution: {integrity: sha512-h9dg2g0qhaRkpYTS+LRDo/CVTlQN+TScBRcT0ah5NvXcrBNWPzGbKjJwFIbKn81+9yWx5l5XEea3Elic2imK5Q==}
+
+  '@modelcontextprotocol/sdk@1.21.2':
+    resolution: {integrity: sha512-HXR5NeVbaL45KuPRqfBQL/hcdc8Y197ALj5G75M5qUMcOk2at0bj2Nns4ZnjU2mTw52360TK63oDqvRjc1iPRQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@multiformats/base-x@4.0.1':
     resolution: {integrity: sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==}
@@ -3081,6 +3106,10 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -3379,6 +3408,10 @@ packages:
     resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
     engines: {node: '>=18'}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -3583,6 +3616,10 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
@@ -3593,6 +3630,10 @@ packages:
 
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
 
   cookie@0.4.2:
     resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
@@ -4117,6 +4158,14 @@ packages:
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
@@ -4125,6 +4174,12 @@ packages:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
 
+  express-rate-limit@7.5.1:
+    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@4.18.2:
     resolution: {integrity: sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==}
     engines: {node: '>= 0.10.0'}
@@ -4132,6 +4187,10 @@ packages:
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -4209,6 +4268,10 @@ packages:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
     engines: {node: '>= 0.8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -4253,6 +4316,10 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   front-matter@4.0.2:
     resolution: {integrity: sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==}
@@ -4494,6 +4561,10 @@ packages:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -4717,6 +4788,9 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -5013,6 +5087,10 @@ packages:
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
 
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -5155,6 +5233,10 @@ packages:
     resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
     engines: {node: '>= 0.6'}
 
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
@@ -5255,6 +5337,10 @@ packages:
 
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
   neotraverse@0.6.18:
@@ -5498,6 +5584,9 @@ packages:
   path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
 
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -5530,6 +5619,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pony-cause@1.1.1:
     resolution: {integrity: sha512-PxkIc/2ZpLiEzQXu5YRDOUgBlfGYBY8156HY5ZcRAwwonMk5W/MrJP2LLkG/hF7GEQzaHo2aS7ho6ZLCOvf+6g==}
@@ -5641,6 +5734,10 @@ packages:
 
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+    engines: {node: '>=0.6'}
+
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -5916,6 +6013,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-async@3.0.0:
     resolution: {integrity: sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==}
     engines: {node: '>=0.12.0'}
@@ -5981,6 +6082,10 @@ packages:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@12.0.0:
     resolution: {integrity: sha512-ZYkZLAvKTKQXWuh5XpBw7CdbSzagarX39WyZ2H07CDLC5/KfsRGlIXV8d4+tfqX1M7916mRqR1QfNHSij+c9Pw==}
     engines: {node: '>=18'}
@@ -5992,6 +6097,10 @@ packages:
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -6150,6 +6259,10 @@ packages:
 
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
@@ -6862,6 +6975,11 @@ packages:
     resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
     peerDependencies:
       zod: ^3.24.1
+
+  zod-to-json-schema@3.25.1:
+    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
 
   zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
@@ -8254,6 +8372,24 @@ snapshots:
       - supports-color
       - typescript
 
+  '@modelcontextprotocol/sdk@1.21.2':
+    dependencies:
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 7.5.1(express@5.2.1)
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.1
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
   '@multiformats/base-x@4.0.1': {}
 
   '@napi-rs/wasm-runtime@1.1.1':
@@ -9609,6 +9745,11 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.11.2):
     dependencies:
       acorn: 8.11.2
@@ -9922,6 +10063,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.0
+      on-finished: 2.4.1
+      qs: 6.15.0
+      raw-body: 3.0.1
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -10114,11 +10269,15 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  content-disposition@1.0.1: {}
+
   content-type@1.0.5: {}
 
   convert-to-spaces@2.0.1: {}
 
   cookie-signature@1.0.6: {}
+
+  cookie-signature@1.2.2: {}
 
   cookie@0.4.2: {}
 
@@ -10669,10 +10828,20 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
 
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
   expand-template@2.0.3:
     optional: true
 
   expect-type@1.2.2: {}
+
+  express-rate-limit@7.5.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
 
   express@4.18.2:
     dependencies:
@@ -10742,6 +10911,39 @@ snapshots:
       statuses: 2.0.1
       type-is: 1.6.18
       utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.1
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -10840,6 +11042,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -10875,6 +11088,8 @@ snapshots:
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   front-matter@4.0.2:
     dependencies:
@@ -11274,6 +11489,14 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -11504,6 +11727,8 @@ snapshots:
       public-ip: 5.0.0
 
   is-plain-obj@4.1.0: {}
+
+  is-promise@4.0.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -11935,6 +12160,8 @@ snapshots:
 
   merge-descriptors@1.0.3: {}
 
+  merge-descriptors@2.0.0: {}
+
   merge2@1.4.1: {}
 
   methods@1.1.2: {}
@@ -12251,6 +12478,10 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   mime@1.6.0: {}
 
   mimic-fn@2.1.0: {}
@@ -12339,6 +12570,8 @@ snapshots:
     optional: true
 
   negotiator@0.6.3: {}
+
+  negotiator@1.0.0: {}
 
   neotraverse@0.6.18: {}
 
@@ -12634,6 +12867,8 @@ snapshots:
 
   path-to-regexp@0.1.7: {}
 
+  path-to-regexp@8.3.0: {}
+
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
@@ -12651,6 +12886,8 @@ snapshots:
   pify@4.0.1: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pony-cause@1.1.1: {}
 
@@ -12789,6 +13026,10 @@ snapshots:
       side-channel: 1.1.0
 
   qs@6.14.0:
+    dependencies:
+      side-channel: 1.1.0
+
+  qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
 
@@ -13244,6 +13485,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.52.5
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   run-async@3.0.0: {}
 
   run-parallel@1.2.0:
@@ -13331,6 +13582,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@12.0.0:
     dependencies:
       type-fest: 4.41.0
@@ -13350,6 +13617,15 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.0
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -13571,6 +13847,8 @@ snapshots:
       zod: 3.25.4
 
   statuses@2.0.1: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -14376,6 +14654,10 @@ snapshots:
       zod: 3.24.0
 
   zod-to-json-schema@3.24.6(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod-to-json-schema@3.25.1(zod@3.25.76):
     dependencies:
       zod: 3.25.76
 

--- a/tools/mcp-server/package.json
+++ b/tools/mcp-server/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@repo/mcp-server",
+  "version": "0.0.1",
+  "private": true,
+  "homepage": "https://github.com/agentcommercekit/ack#readme",
+  "bugs": "https://github.com/agentcommercekit/ack/issues",
+  "license": "MIT",
+  "author": {
+    "name": "Catena Labs",
+    "url": "https://catenalabs.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/agentcommercekit/ack.git",
+    "directory": "tools/mcp-server"
+  },
+  "bin": {
+    "ack-mcp": "./src/index.ts"
+  },
+  "type": "module",
+  "main": "./src/index.ts",
+  "scripts": {
+    "check:types": "tsc --noEmit",
+    "clean": "git clean -fdX .turbo",
+    "start": "tsx ./src/index.ts",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.21.2",
+    "agentcommercekit": "workspace:*",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*"
+  }
+}

--- a/tools/mcp-server/src/index.ts
+++ b/tools/mcp-server/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/**
+ * ACK MCP Server
+ *
+ * Exposes Agent Commerce Kit operations as MCP tools, enabling any
+ * MCP-compatible AI agent to create credentials, verify identities,
+ * issue payment requests, and verify receipts.
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+
+import { registerIdentityTools } from "./tools/identity"
+import { registerPaymentReceiptTools } from "./tools/payment-receipts"
+import { registerPaymentRequestTools } from "./tools/payment-requests"
+import { registerUtilityTools } from "./tools/utility"
+
+const server = new McpServer({
+  name: "ack",
+  version: "0.0.1",
+})
+
+registerIdentityTools(server)
+registerPaymentRequestTools(server)
+registerPaymentReceiptTools(server)
+registerUtilityTools(server)
+
+const transport = new StdioServerTransport()
+await server.connect(transport)

--- a/tools/mcp-server/src/index.ts
+++ b/tools/mcp-server/src/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S npx tsx
 /**
  * ACK MCP Server
  *

--- a/tools/mcp-server/src/server.test.ts
+++ b/tools/mcp-server/src/server.test.ts
@@ -121,8 +121,8 @@ describe("MCP server over stdio", () => {
     const credResult = await client.callTool({
       name: "ack_create_controller_credential",
       arguments: {
-        subject: agent.did,
-        controller: owner.did,
+        subjectDid: agent.did,
+        controllerDid: owner.did,
       },
     })
     expect(credResult.isError).toBeFalsy()
@@ -135,8 +135,8 @@ describe("MCP server over stdio", () => {
       name: "ack_sign_credential",
       arguments: {
         credential,
-        jwk: owner.jwk,
-        did: owner.did,
+        signerJwk: owner.jwk,
+        signerDid: owner.did,
       },
     })
     expect(signResult.isError).toBeFalsy()

--- a/tools/mcp-server/src/server.test.ts
+++ b/tools/mcp-server/src/server.test.ts
@@ -1,0 +1,159 @@
+/**
+ * MCP transport-level smoke tests.
+ *
+ * Spawns the actual server over stdio, performs the MCP handshake,
+ * and exercises tools through the protocol — the same path a real
+ * MCP client (Claude, Cursor, etc.) would take.
+ */
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+
+const EXPECTED_TOOLS = [
+  "ack_create_controller_credential",
+  "ack_sign_credential",
+  "ack_verify_credential",
+  "ack_resolve_did",
+  "ack_create_payment_request",
+  "ack_verify_payment_request",
+  "ack_create_payment_receipt",
+  "ack_verify_payment_receipt",
+  "ack_generate_keypair",
+]
+
+describe("MCP server over stdio", () => {
+  let client: Client
+  let transport: StdioClientTransport
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: "tsx",
+      args: ["./src/index.ts"],
+      cwd: import.meta.dirname + "/..",
+      stderr: "pipe",
+    })
+
+    client = new Client({ name: "test-client", version: "0.0.1" })
+    await client.connect(transport)
+  }, 15_000)
+
+  afterAll(async () => {
+    await client.close()
+  })
+
+  it("completes the MCP handshake", () => {
+    const info = client.getServerVersion()
+    expect(info).toBeDefined()
+    expect(info!.name).toBe("ack")
+  })
+
+  it("lists all 9 tools", async () => {
+    const { tools } = await client.listTools()
+    const names = tools.map((t) => t.name).sort()
+    expect(names).toEqual([...EXPECTED_TOOLS].sort())
+  })
+
+  it("generates a keypair via ack_generate_keypair", async () => {
+    const result = await client.callTool({
+      name: "ack_generate_keypair",
+      arguments: { curve: "Ed25519" },
+    })
+
+    expect(result.isError).toBeFalsy()
+
+    const text = (result.content as Array<{ type: string; text: string }>)[0]!
+      .text
+    const parsed = JSON.parse(text)
+
+    expect(parsed.curve).toBe("Ed25519")
+    expect(parsed.did).toMatch(/^did:key:z6Mk/)
+    expect(parsed.jwk).toBeDefined()
+  })
+
+  it("resolves a did:key via ack_resolve_did", async () => {
+    // Generate a key first, then resolve its DID
+    const genResult = await client.callTool({
+      name: "ack_generate_keypair",
+      arguments: { curve: "secp256k1" },
+    })
+
+    const genText = (
+      genResult.content as Array<{ type: string; text: string }>
+    )[0]!.text
+    const { did } = JSON.parse(genText)
+
+    const resolveResult = await client.callTool({
+      name: "ack_resolve_did",
+      arguments: { did },
+    })
+
+    expect(resolveResult.isError).toBeFalsy()
+
+    const resolveText = (
+      resolveResult.content as Array<{ type: string; text: string }>
+    )[0]!.text
+    const doc = JSON.parse(resolveText)
+
+    expect(doc.did).toBe(did)
+    expect(doc.didDocument).toBeDefined()
+    expect(doc.didDocument.verificationMethod).toBeDefined()
+  })
+
+  it("round-trips sign and verify through the protocol", async () => {
+    // Generate owner + agent keypairs
+    const ownerResult = await client.callTool({
+      name: "ack_generate_keypair",
+      arguments: { curve: "secp256k1" },
+    })
+    const owner = JSON.parse(
+      (ownerResult.content as Array<{ type: string; text: string }>)[0]!.text,
+    )
+
+    const agentResult = await client.callTool({
+      name: "ack_generate_keypair",
+      arguments: { curve: "secp256k1" },
+    })
+    const agent = JSON.parse(
+      (agentResult.content as Array<{ type: string; text: string }>)[0]!.text,
+    )
+
+    // Create a controller credential
+    const credResult = await client.callTool({
+      name: "ack_create_controller_credential",
+      arguments: {
+        subject: agent.did,
+        controller: owner.did,
+      },
+    })
+    expect(credResult.isError).toBeFalsy()
+    const credential = (
+      credResult.content as Array<{ type: string; text: string }>
+    )[0]!.text
+
+    // Sign it
+    const signResult = await client.callTool({
+      name: "ack_sign_credential",
+      arguments: {
+        credential,
+        jwk: owner.jwk,
+        did: owner.did,
+      },
+    })
+    expect(signResult.isError).toBeFalsy()
+    const jwt = (
+      signResult.content as Array<{ type: string; text: string }>
+    )[0]!.text
+    expect(jwt).toMatch(/^eyJ/)
+
+    // Verify it
+    const verifyResult = await client.callTool({
+      name: "ack_verify_credential",
+      arguments: { jwt },
+    })
+    expect(verifyResult.isError).toBeFalsy()
+    const verification = JSON.parse(
+      (verifyResult.content as Array<{ type: string; text: string }>)[0]!.text,
+    )
+    expect(verification.valid).toBe(true)
+  })
+})

--- a/tools/mcp-server/src/tools/identity.test.ts
+++ b/tools/mcp-server/src/tools/identity.test.ts
@@ -1,0 +1,71 @@
+import {
+  createControllerCredential,
+  createDidKeyUri,
+  createJwtSigner,
+  generateKeypair,
+  keypairToJwk,
+  signCredential,
+  type DidUri,
+} from "agentcommercekit"
+import { describe, expect, it } from "vitest"
+
+import { curveToAlg } from "../util"
+
+describe("identity tool operations", () => {
+  it("creates a controller credential with correct structure", () => {
+    const credential = createControllerCredential({
+      subject: "did:key:z6MkSubject" as DidUri,
+      controller: "did:key:z6MkController" as DidUri,
+    })
+
+    expect(credential.type).toContain("ControllerCredential")
+    expect(credential.issuer).toEqual({ id: "did:key:z6MkController" })
+    expect(credential.credentialSubject.controller).toBe(
+      "did:key:z6MkController",
+    )
+  })
+
+  it("signs a credential and produces a valid JWT", async () => {
+    const keypair = await generateKeypair("secp256k1")
+    const did = createDidKeyUri(keypair)
+    const signer = createJwtSigner(keypair)
+
+    const credential = createControllerCredential({
+      subject: "did:key:z6MkSubject" as DidUri,
+      controller: did,
+    })
+
+    const jwt = await signCredential(credential, {
+      did,
+      signer,
+      alg: curveToAlg(keypair.curve),
+    })
+
+    expect(jwt).toMatch(/^eyJ/)
+    expect(jwt.split(".")).toHaveLength(3)
+  })
+
+  it("round-trips a keypair through JWK for signing", async () => {
+    const keypair = await generateKeypair("secp256k1")
+    const did = createDidKeyUri(keypair)
+    const jwk = keypairToJwk(keypair)
+
+    // Simulate what the MCP tool does: reconstruct from JWK
+    const { jwkToKeypair } = await import("agentcommercekit")
+    const restored = jwkToKeypair(jwk)
+    const signer = createJwtSigner(restored)
+
+    const credential = createControllerCredential({
+      subject: "did:key:z6MkSubject" as DidUri,
+      controller: did,
+    })
+
+    const jwt = await signCredential(credential, {
+      did,
+      signer,
+      alg: curveToAlg(restored.curve),
+    })
+
+    expect(jwt).toMatch(/^eyJ/)
+  })
+})

--- a/tools/mcp-server/src/tools/identity.ts
+++ b/tools/mcp-server/src/tools/identity.ts
@@ -108,7 +108,8 @@ export function registerIdentityTools(server: McpServer) {
           subject: credential.credentialSubject,
         })
       } catch (e) {
-        return verification(false, { reason: (e as Error).message })
+        const reason = e instanceof Error ? e.message : String(e)
+        return verification(false, { reason })
       }
     },
   )

--- a/tools/mcp-server/src/tools/identity.ts
+++ b/tools/mcp-server/src/tools/identity.ts
@@ -71,7 +71,11 @@ export function registerIdentityTools(server: McpServer) {
     async ({ credential, jwk, did }) => {
       try {
         const keypair = keypairFromJwk(jwk)
-        const jwt = await signCredential(JSON.parse(credential), {
+        const parsed = JSON.parse(credential)
+        if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+          throw new Error("credential must be a JSON object")
+        }
+        const jwt = await signCredential(parsed, {
           did: did as DidUri,
           signer: createJwtSigner(keypair),
           alg: curveToAlg(keypair.curve),

--- a/tools/mcp-server/src/tools/identity.ts
+++ b/tools/mcp-server/src/tools/identity.ts
@@ -1,0 +1,129 @@
+/**
+ * ACK-ID identity tools for MCP.
+ */
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import {
+  createControllerCredential,
+  createJwtSigner,
+  parseJwtCredential,
+  resolveDid,
+  signCredential,
+  verifyParsedCredential,
+  type DidUri,
+  type JwtString,
+} from "agentcommercekit"
+import { z } from "zod"
+
+import {
+  curveToAlg,
+  err,
+  keypairFromJwk,
+  ok,
+  resolver,
+  verification,
+} from "../util"
+
+export function registerIdentityTools(server: McpServer) {
+  server.tool(
+    "ack_create_controller_credential",
+    "Create a W3C Verifiable Credential proving that a subject DID is controlled by a controller DID.",
+    {
+      subject: z
+        .string()
+        .describe("DID of the subject (the entity being controlled)"),
+      controller: z
+        .string()
+        .describe("DID of the controller (the entity with authority)"),
+      issuer: z
+        .string()
+        .optional()
+        .describe("DID of the issuer. Defaults to the controller."),
+    },
+    async ({ subject, controller, issuer }) => {
+      try {
+        const credential = createControllerCredential({
+          subject: subject as DidUri,
+          controller: controller as DidUri,
+          issuer: issuer as DidUri | undefined,
+        })
+        return ok(credential)
+      } catch (e) {
+        return err(e)
+      }
+    },
+  )
+
+  server.tool(
+    "ack_sign_credential",
+    "Sign a W3C Verifiable Credential, returning a signed JWT string. The jwk parameter should be the JWK string returned by ack_generate_keypair.",
+    {
+      credential: z
+        .string()
+        .describe("JSON string of the W3C credential to sign"),
+      jwk: z
+        .string()
+        .describe(
+          "JWK JSON string containing the private key (from ack_generate_keypair)",
+        ),
+      did: z.string().describe("DID of the signer"),
+    },
+    async ({ credential, jwk, did }) => {
+      try {
+        const keypair = keypairFromJwk(jwk)
+        const jwt = await signCredential(JSON.parse(credential), {
+          did: did as DidUri,
+          signer: createJwtSigner(keypair),
+          alg: curveToAlg(keypair.curve),
+        })
+        return ok(jwt)
+      } catch (e) {
+        return err(e)
+      }
+    },
+  )
+
+  server.tool(
+    "ack_verify_credential",
+    "Verify a signed credential JWT. Checks signature, expiration, and optionally trusted issuers.",
+    {
+      jwt: z.string().describe("The signed credential JWT string"),
+      trustedIssuers: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "List of trusted issuer DIDs. If provided, the credential issuer must be in this list.",
+        ),
+    },
+    async ({ jwt, trustedIssuers }) => {
+      try {
+        const credential = await parseJwtCredential(jwt as JwtString, resolver)
+        await verifyParsedCredential(credential, {
+          resolver,
+          trustedIssuers,
+        })
+        return verification(true, {
+          issuer: credential.issuer,
+          type: credential.type,
+          subject: credential.credentialSubject,
+        })
+      } catch (e) {
+        return verification(false, { reason: (e as Error).message })
+      }
+    },
+  )
+
+  server.tool(
+    "ack_resolve_did",
+    "Resolve a DID URI to its DID Document. Supports did:key, did:web, and did:pkh methods.",
+    {
+      did: z.string().describe("The DID URI to resolve"),
+    },
+    async ({ did }) => {
+      try {
+        return ok(await resolveDid(did, resolver))
+      } catch (e) {
+        return err(e)
+      }
+    },
+  )
+}

--- a/tools/mcp-server/src/tools/identity.ts
+++ b/tools/mcp-server/src/tools/identity.ts
@@ -23,6 +23,7 @@ import {
   verification,
 } from "../util"
 
+/** Register ACK-ID identity tools on the MCP server. */
 export function registerIdentityTools(server: McpServer) {
   server.tool(
     "ack_create_controller_credential",

--- a/tools/mcp-server/src/tools/identity.ts
+++ b/tools/mcp-server/src/tools/identity.ts
@@ -27,20 +27,20 @@ import {
 export function registerIdentityTools(server: McpServer) {
   server.tool(
     "ack_create_controller_credential",
-    "Create a W3C Verifiable Credential proving that a subject DID is controlled by a controller DID.",
+    "Create a W3C Verifiable Credential proving that a subject DID (e.g. an agent) is controlled by a controller DID (e.g. the owner). Requires both subjectDid and controllerDid.",
     {
-      subject: z
+      subjectDid: z
         .string()
-        .describe("DID of the subject (the entity being controlled)"),
-      controller: z
+        .describe("DID of the agent or entity being controlled"),
+      controllerDid: z
         .string()
-        .describe("DID of the controller (the entity with authority)"),
-      issuer: z
+        .describe("DID of the owner or entity with authority"),
+      issuerDid: z
         .string()
         .optional()
         .describe("DID of the issuer. Defaults to the controller."),
     },
-    async ({ subject, controller, issuer }) => {
+    async ({ subjectDid: subject, controllerDid: controller, issuerDid: issuer }) => {
       try {
         const credential = createControllerCredential({
           subject: subject as DidUri,
@@ -56,19 +56,19 @@ export function registerIdentityTools(server: McpServer) {
 
   server.tool(
     "ack_sign_credential",
-    "Sign a W3C Verifiable Credential, returning a signed JWT string. The jwk parameter should be the JWK string returned by ack_generate_keypair.",
+    "Sign a W3C Verifiable Credential, returning a signed JWT string. Requires the credential JSON, the signer's JWK (from ack_generate_keypair), and the signer's DID.",
     {
       credential: z
         .string()
         .describe("JSON string of the W3C credential to sign"),
-      jwk: z
+      signerJwk: z
         .string()
         .describe(
-          "JWK JSON string containing the private key (from ack_generate_keypair)",
+          "JWK JSON string containing the signer's private key (from ack_generate_keypair)",
         ),
-      did: z.string().describe("DID of the signer"),
+      signerDid: z.string().describe("DID of the signer (must match the JWK)"),
     },
-    async ({ credential, jwk, did }) => {
+    async ({ credential, signerJwk: jwk, signerDid: did }) => {
       try {
         const keypair = keypairFromJwk(jwk)
         const parsed = JSON.parse(credential)

--- a/tools/mcp-server/src/tools/payment-receipts.test.ts
+++ b/tools/mcp-server/src/tools/payment-receipts.test.ts
@@ -1,0 +1,131 @@
+import {
+  createDidKeyUri,
+  createJwtSigner,
+  createPaymentReceipt,
+  createSignedPaymentRequest,
+  generateKeypair,
+  getDidResolver,
+  signCredential,
+  verifyPaymentReceipt,
+  type DidUri,
+} from "agentcommercekit"
+import { describe, expect, it } from "vitest"
+
+import { curveToAlg } from "../util"
+
+const resolver = getDidResolver()
+
+async function createTestPaymentRequest() {
+  const keypair = await generateKeypair("secp256k1")
+  const did = createDidKeyUri(keypair)
+  const signer = createJwtSigner(keypair)
+
+  const { paymentRequestToken } = await createSignedPaymentRequest(
+    {
+      id: crypto.randomUUID(),
+      paymentOptions: [
+        {
+          id: "opt-1",
+          amount: 100,
+          decimals: 6,
+          currency: "USDC",
+          recipient: "0x1234567890abcdef1234567890abcdef12345678",
+        },
+      ],
+    },
+    { issuer: did, signer, algorithm: curveToAlg(keypair.curve) },
+  )
+
+  return { keypair, did, signer, paymentRequestToken }
+}
+
+describe("payment receipt operations", () => {
+  it("creates, signs, and verifies a payment receipt", async () => {
+    const { keypair, did, paymentRequestToken } =
+      await createTestPaymentRequest()
+
+    const payerKeypair = await generateKeypair("secp256k1")
+    const payerDid = createDidKeyUri(payerKeypair)
+
+    const receipt = createPaymentReceipt({
+      paymentRequestToken,
+      paymentOptionId: "opt-1",
+      issuer: did,
+      payerDid,
+    })
+
+    expect(receipt.type).toContain("PaymentReceiptCredential")
+
+    const signedReceipt = await signCredential(receipt, {
+      did,
+      signer: createJwtSigner(keypair),
+      alg: curveToAlg(keypair.curve),
+    })
+
+    const result = await verifyPaymentReceipt(signedReceipt, {
+      resolver,
+      trustedReceiptIssuers: [did],
+    })
+
+    expect(result.receipt).toBeDefined()
+  })
+
+  it("rejects a receipt from an untrusted issuer", async () => {
+    const { keypair, did, paymentRequestToken } =
+      await createTestPaymentRequest()
+
+    const payerKeypair = await generateKeypair("secp256k1")
+    const payerDid = createDidKeyUri(payerKeypair)
+
+    const receipt = createPaymentReceipt({
+      paymentRequestToken,
+      paymentOptionId: "opt-1",
+      issuer: did,
+      payerDid,
+    })
+
+    const signedReceipt = await signCredential(receipt, {
+      did,
+      signer: createJwtSigner(keypair),
+      alg: curveToAlg(keypair.curve),
+    })
+
+    const otherKeypair = await generateKeypair("secp256k1")
+    const untrustedDid = createDidKeyUri(otherKeypair)
+
+    await expect(
+      verifyPaymentReceipt(signedReceipt, {
+        resolver,
+        trustedReceiptIssuers: [untrustedDid],
+      }),
+    ).rejects.toThrow()
+  })
+
+  it("rejects a receipt with wrong payment request issuer", async () => {
+    const { keypair, did, paymentRequestToken } =
+      await createTestPaymentRequest()
+
+    const payerKeypair = await generateKeypair("secp256k1")
+    const payerDid = createDidKeyUri(payerKeypair)
+
+    const receipt = createPaymentReceipt({
+      paymentRequestToken,
+      paymentOptionId: "opt-1",
+      issuer: did,
+      payerDid,
+    })
+
+    const signedReceipt = await signCredential(receipt, {
+      did,
+      signer: createJwtSigner(keypair),
+      alg: curveToAlg(keypair.curve),
+    })
+
+    await expect(
+      verifyPaymentReceipt(signedReceipt, {
+        resolver,
+        paymentRequestIssuer: "did:key:z6MkWrongIssuer" as DidUri,
+      }),
+    ).rejects.toThrow()
+  })
+})

--- a/tools/mcp-server/src/tools/payment-receipts.ts
+++ b/tools/mcp-server/src/tools/payment-receipts.ts
@@ -11,6 +11,7 @@ import { z } from "zod"
 
 import { err, ok, resolver, verification } from "../util"
 
+/** Register ACK-Pay payment receipt tools on the MCP server. */
 export function registerPaymentReceiptTools(server: McpServer) {
   server.tool(
     "ack_create_payment_receipt",

--- a/tools/mcp-server/src/tools/payment-receipts.ts
+++ b/tools/mcp-server/src/tools/payment-receipts.ts
@@ -80,7 +80,8 @@ export function registerPaymentReceiptTools(server: McpServer) {
           paymentRequest: result.paymentRequest,
         })
       } catch (e) {
-        return verification(false, { reason: (e as Error).message })
+        const reason = e instanceof Error ? e.message : String(e)
+        return verification(false, { reason })
       }
     },
   )

--- a/tools/mcp-server/src/tools/payment-receipts.ts
+++ b/tools/mcp-server/src/tools/payment-receipts.ts
@@ -1,0 +1,86 @@
+/**
+ * ACK-Pay payment receipt tools for MCP.
+ */
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import {
+  createPaymentReceipt,
+  verifyPaymentReceipt,
+  type DidUri,
+} from "agentcommercekit"
+import { z } from "zod"
+
+import { err, ok, resolver, verification } from "../util"
+
+export function registerPaymentReceiptTools(server: McpServer) {
+  server.tool(
+    "ack_create_payment_receipt",
+    "Create a payment receipt as a W3C Verifiable Credential, proving that a payment was made.",
+    {
+      paymentRequestToken: z
+        .string()
+        .describe("The original payment request JWT that was fulfilled"),
+      paymentOptionId: z
+        .string()
+        .describe("ID of the payment option that was used"),
+      issuerDid: z
+        .string()
+        .describe("DID of the receipt issuer (typically the payment receiver)"),
+      payerDid: z.string().describe("DID of the entity that made the payment"),
+      metadata: z
+        .record(z.unknown())
+        .optional()
+        .describe("Optional metadata about the payment"),
+    },
+    async ({
+      paymentRequestToken,
+      paymentOptionId,
+      issuerDid,
+      payerDid,
+      metadata,
+    }) => {
+      try {
+        const receipt = createPaymentReceipt({
+          paymentRequestToken,
+          paymentOptionId,
+          issuer: issuerDid as DidUri,
+          payerDid: payerDid as DidUri,
+          metadata,
+        })
+        return ok(receipt)
+      } catch (e) {
+        return err(e)
+      }
+    },
+  )
+
+  server.tool(
+    "ack_verify_payment_receipt",
+    "Verify a payment receipt credential. Checks the receipt signature and optionally verifies the embedded payment request.",
+    {
+      receipt: z.string().describe("The receipt as a signed JWT string"),
+      trustedReceiptIssuers: z
+        .array(z.string())
+        .optional()
+        .describe("Trusted receipt issuer DIDs"),
+      paymentRequestIssuer: z
+        .string()
+        .optional()
+        .describe("Expected payment request issuer DID"),
+    },
+    async ({ receipt, trustedReceiptIssuers, paymentRequestIssuer }) => {
+      try {
+        const result = await verifyPaymentReceipt(receipt, {
+          resolver,
+          trustedReceiptIssuers,
+          paymentRequestIssuer,
+        })
+        return verification(true, {
+          receipt: result.receipt,
+          paymentRequest: result.paymentRequest,
+        })
+      } catch (e) {
+        return verification(false, { reason: (e as Error).message })
+      }
+    },
+  )
+}

--- a/tools/mcp-server/src/tools/payment-requests.test.ts
+++ b/tools/mcp-server/src/tools/payment-requests.test.ts
@@ -1,0 +1,85 @@
+import {
+  createDidKeyUri,
+  createJwtSigner,
+  createSignedPaymentRequest,
+  generateKeypair,
+  verifyPaymentRequestToken,
+  getDidResolver,
+  type DidUri,
+  type PaymentRequestInit,
+} from "agentcommercekit"
+import { describe, expect, it } from "vitest"
+
+import { curveToAlg } from "../util"
+
+const resolver = getDidResolver()
+
+describe("payment tool operations", () => {
+  it("creates and verifies a payment request token", async () => {
+    const keypair = await generateKeypair("secp256k1")
+    const did = createDidKeyUri(keypair)
+    const signer = createJwtSigner(keypair)
+
+    const init: PaymentRequestInit = {
+      id: crypto.randomUUID(),
+      description: "Test payment",
+      paymentOptions: [
+        {
+          id: "option-1",
+          amount: 100,
+          decimals: 6,
+          currency: "USDC",
+          recipient: "0x1234567890abcdef1234567890abcdef12345678",
+        },
+      ],
+    }
+
+    const { paymentRequest, paymentRequestToken } =
+      await createSignedPaymentRequest(init, {
+        issuer: did,
+        signer,
+        algorithm: curveToAlg(keypair.curve),
+      })
+
+    expect(paymentRequest.id).toBe(init.id)
+    expect(paymentRequestToken).toMatch(/^eyJ/)
+
+    // Verify the token
+    const { paymentRequest: verified } = await verifyPaymentRequestToken(
+      paymentRequestToken,
+      { resolver },
+    )
+
+    expect(verified.id).toBe(init.id)
+    expect(verified.paymentOptions[0]!.currency).toBe("USDC")
+  })
+
+  it("rejects a payment request with wrong issuer", async () => {
+    const keypair = await generateKeypair("secp256k1")
+    const did = createDidKeyUri(keypair)
+    const signer = createJwtSigner(keypair)
+
+    const { paymentRequestToken } = await createSignedPaymentRequest(
+      {
+        id: crypto.randomUUID(),
+        paymentOptions: [
+          {
+            id: "opt-1",
+            amount: 50,
+            decimals: 6,
+            currency: "USDC",
+            recipient: "0xrecipient",
+          },
+        ],
+      },
+      { issuer: did, signer, algorithm: "ES256K" },
+    )
+
+    await expect(
+      verifyPaymentRequestToken(paymentRequestToken, {
+        resolver,
+        issuer: "did:key:z6MkWrongIssuer",
+      }),
+    ).rejects.toThrow()
+  })
+})

--- a/tools/mcp-server/src/tools/payment-requests.test.ts
+++ b/tools/mcp-server/src/tools/payment-requests.test.ts
@@ -82,4 +82,53 @@ describe("payment tool operations", () => {
       }),
     ).rejects.toThrow()
   })
+
+  it("creates a payment request with expiresInSeconds and verifies expiry is set", async () => {
+    const keypair = await generateKeypair("secp256k1")
+    const did = createDidKeyUri(keypair)
+    const signer = createJwtSigner(keypair)
+
+    const before = Date.now()
+    const expiresInSeconds = 3600
+
+    const { paymentRequest } = await createSignedPaymentRequest(
+      {
+        id: crypto.randomUUID(),
+        paymentOptions: [
+          {
+            id: "opt-1",
+            amount: 100,
+            decimals: 6,
+            currency: "USDC",
+            recipient: "0x1234567890abcdef1234567890abcdef12345678",
+          },
+        ],
+        expiresAt: new Date(Date.now() + expiresInSeconds * 1000).toISOString(),
+      },
+      { issuer: did, signer, algorithm: curveToAlg(keypair.curve) },
+    )
+
+    const expiresAt = new Date(paymentRequest.expiresAt!).getTime()
+    const expectedMin = before + expiresInSeconds * 1000
+    const expectedMax = Date.now() + expiresInSeconds * 1000
+
+    expect(expiresAt).toBeGreaterThanOrEqual(expectedMin)
+    expect(expiresAt).toBeLessThanOrEqual(expectedMax)
+  })
+
+  it("requires at least one payment option", async () => {
+    const keypair = await generateKeypair("secp256k1")
+    const did = createDidKeyUri(keypair)
+    const signer = createJwtSigner(keypair)
+
+    await expect(
+      createSignedPaymentRequest(
+        {
+          id: crypto.randomUUID(),
+          paymentOptions: [] as unknown as [{ id: string; amount: number; decimals: number; currency: string; recipient: string }],
+        },
+        { issuer: did, signer, algorithm: curveToAlg(keypair.curve) },
+      ),
+    ).rejects.toThrow()
+  })
 })

--- a/tools/mcp-server/src/tools/payment-requests.ts
+++ b/tools/mcp-server/src/tools/payment-requests.ts
@@ -52,14 +52,14 @@ export function registerPaymentRequestTools(server: McpServer) {
         .positive()
         .optional()
         .describe("Seconds until the payment request expires"),
-      jwk: z
+      signerJwk: z
         .string()
         .describe(
-          "JWK JSON string containing the private key (from ack_generate_keypair)",
+          "JWK JSON string containing the signer's private key (from ack_generate_keypair)",
         ),
-      did: z.string().describe("DID of the payment requester"),
+      signerDid: z.string().describe("DID of the payment requester (must match the JWK)"),
     },
-    async ({ description, paymentOptions, expiresInSeconds, jwk, did }) => {
+    async ({ description, paymentOptions, expiresInSeconds, signerJwk: jwk, signerDid: did }) => {
       try {
         if (paymentOptions.length === 0) {
           throw new Error("At least one payment option is required")

--- a/tools/mcp-server/src/tools/payment-requests.ts
+++ b/tools/mcp-server/src/tools/payment-requests.ts
@@ -75,7 +75,7 @@ export function registerPaymentRequestTools(server: McpServer) {
           ],
         }
 
-        if (expiresInSeconds) {
+        if (expiresInSeconds !== undefined) {
           init.expiresAt = new Date(
             Date.now() + expiresInSeconds * 1000,
           ).toISOString()

--- a/tools/mcp-server/src/tools/payment-requests.ts
+++ b/tools/mcp-server/src/tools/payment-requests.ts
@@ -49,7 +49,7 @@ export function registerPaymentRequestTools(server: McpServer) {
       expiresInSeconds: z
         .number()
         .int()
-        .nonnegative()
+        .positive()
         .optional()
         .describe("Seconds until the payment request expires"),
       jwk: z

--- a/tools/mcp-server/src/tools/payment-requests.ts
+++ b/tools/mcp-server/src/tools/payment-requests.ts
@@ -1,0 +1,123 @@
+/**
+ * ACK-Pay payment request tools for MCP.
+ */
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import {
+  createJwtSigner,
+  createSignedPaymentRequest,
+  verifyPaymentRequestToken,
+  type DidUri,
+  type PaymentRequestInit,
+} from "agentcommercekit"
+import { z } from "zod"
+
+import {
+  curveToAlg,
+  err,
+  keypairFromJwk,
+  ok,
+  resolver,
+  verification,
+} from "../util"
+
+const paymentOptionSchema = z.object({
+  id: z.string(),
+  amount: z.union([z.number(), z.string()]),
+  decimals: z.number(),
+  currency: z.string(),
+  recipient: z.string(),
+  network: z.string().optional(),
+  paymentService: z.string().optional(),
+  receiptService: z.string().optional(),
+})
+
+export function registerPaymentRequestTools(server: McpServer) {
+  server.tool(
+    "ack_create_payment_request",
+    "Create a signed payment request token (JWT) for use in HTTP 402 responses. The jwk parameter should be the JWK string returned by ack_generate_keypair.",
+    {
+      description: z
+        .string()
+        .optional()
+        .describe("Human-readable description of what the payment is for"),
+      paymentOptions: z
+        .array(paymentOptionSchema)
+        .describe(
+          "Array of payment options (amount, currency, recipient, network)",
+        ),
+      expiresInSeconds: z
+        .number()
+        .optional()
+        .default(3600)
+        .describe("Seconds until the payment request expires"),
+      jwk: z
+        .string()
+        .describe(
+          "JWK JSON string containing the private key (from ack_generate_keypair)",
+        ),
+      did: z.string().describe("DID of the payment requester"),
+    },
+    async ({ description, paymentOptions, expiresInSeconds, jwk, did }) => {
+      try {
+        if (paymentOptions.length === 0) {
+          throw new Error("At least one payment option is required")
+        }
+
+        const keypair = keypairFromJwk(jwk)
+
+        const init: PaymentRequestInit = {
+          id: crypto.randomUUID(),
+          description,
+          paymentOptions: paymentOptions as [
+            (typeof paymentOptions)[0],
+            ...typeof paymentOptions,
+          ],
+        }
+
+        if (expiresInSeconds) {
+          init.expiresAt = new Date(
+            Date.now() + expiresInSeconds * 1000,
+          ).toISOString()
+        }
+
+        const result = await createSignedPaymentRequest(init, {
+          issuer: did as DidUri,
+          signer: createJwtSigner(keypair),
+          algorithm: curveToAlg(keypair.curve),
+        })
+
+        return ok(result)
+      } catch (e) {
+        return err(e)
+      }
+    },
+  )
+
+  server.tool(
+    "ack_verify_payment_request",
+    "Verify and parse a payment request JWT. Returns the decoded payment request if valid.",
+    {
+      token: z.string().describe("The payment request JWT string"),
+      issuer: z
+        .string()
+        .optional()
+        .describe(
+          "Expected issuer DID. If provided, verifies the token was issued by this DID.",
+        ),
+    },
+    async ({ token, issuer }) => {
+      try {
+        const { paymentRequest, parsed } = await verifyPaymentRequestToken(
+          token,
+          { resolver, issuer },
+        )
+        return verification(true, {
+          paymentRequest,
+          issuer: parsed.issuer,
+        })
+      } catch (e) {
+        return verification(false, { reason: (e as Error).message })
+      }
+    },
+  )
+}

--- a/tools/mcp-server/src/tools/payment-requests.ts
+++ b/tools/mcp-server/src/tools/payment-requests.ts
@@ -48,8 +48,9 @@ export function registerPaymentRequestTools(server: McpServer) {
         ),
       expiresInSeconds: z
         .number()
+        .int()
+        .nonnegative()
         .optional()
-        .default(3600)
         .describe("Seconds until the payment request expires"),
       jwk: z
         .string()
@@ -117,7 +118,8 @@ export function registerPaymentRequestTools(server: McpServer) {
           issuer: parsed.issuer,
         })
       } catch (e) {
-        return verification(false, { reason: (e as Error).message })
+        const reason = e instanceof Error ? e.message : String(e)
+        return verification(false, { reason })
       }
     },
   )

--- a/tools/mcp-server/src/tools/payment-requests.ts
+++ b/tools/mcp-server/src/tools/payment-requests.ts
@@ -31,6 +31,7 @@ const paymentOptionSchema = z.object({
   receiptService: z.string().optional(),
 })
 
+/** Register ACK-Pay payment request tools on the MCP server. */
 export function registerPaymentRequestTools(server: McpServer) {
   server.tool(
     "ack_create_payment_request",

--- a/tools/mcp-server/src/tools/utility.ts
+++ b/tools/mcp-server/src/tools/utility.ts
@@ -1,0 +1,40 @@
+/**
+ * Utility tools for MCP.
+ */
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import {
+  bytesToHexString,
+  createDidKeyUri,
+  generateKeypair,
+  keypairToJwk,
+} from "agentcommercekit"
+import { z } from "zod"
+
+import { err, ok } from "../util"
+
+export function registerUtilityTools(server: McpServer) {
+  server.tool(
+    "ack_generate_keypair",
+    "Generate a new cryptographic keypair. Returns the private key (hex), public key (hex), JWK, DID, and curve. Use the JWK value when calling other tools that require signing.",
+    {
+      curve: z
+        .enum(["secp256k1", "secp256r1", "Ed25519"])
+        .default("secp256k1")
+        .describe("Cryptographic curve to use"),
+    },
+    async ({ curve }) => {
+      try {
+        const keypair = await generateKeypair(curve)
+        return ok({
+          curve,
+          did: createDidKeyUri(keypair),
+          jwk: JSON.stringify(keypairToJwk(keypair)),
+          privateKey: bytesToHexString(keypair.privateKey),
+          publicKey: bytesToHexString(keypair.publicKey),
+        })
+      } catch (e) {
+        return err(e)
+      }
+    },
+  )
+}

--- a/tools/mcp-server/src/tools/utility.ts
+++ b/tools/mcp-server/src/tools/utility.ts
@@ -12,6 +12,7 @@ import { z } from "zod"
 
 import { err, ok } from "../util"
 
+/** Register utility tools (keypair generation) on the MCP server. */
 export function registerUtilityTools(server: McpServer) {
   server.tool(
     "ack_generate_keypair",

--- a/tools/mcp-server/src/tools/utility.ts
+++ b/tools/mcp-server/src/tools/utility.ts
@@ -3,7 +3,6 @@
  */
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import {
-  bytesToHexString,
   createDidKeyUri,
   generateKeypair,
   keypairToJwk,
@@ -16,7 +15,7 @@ import { err, ok } from "../util"
 export function registerUtilityTools(server: McpServer) {
   server.tool(
     "ack_generate_keypair",
-    "Generate a new cryptographic keypair. Returns the private key (hex), public key (hex), JWK, DID, and curve. Use the JWK value when calling other tools that require signing.",
+    "Generate a new cryptographic keypair. Returns the JWK, DID, and curve. Use the JWK value when calling other tools that require signing.",
     {
       curve: z
         .enum(["secp256k1", "secp256r1", "Ed25519"])
@@ -30,8 +29,6 @@ export function registerUtilityTools(server: McpServer) {
           curve,
           did: createDidKeyUri(keypair),
           jwk: JSON.stringify(keypairToJwk(keypair)),
-          privateKey: bytesToHexString(keypair.privateKey),
-          publicKey: bytesToHexString(keypair.publicKey),
         })
       } catch (e) {
         return err(e)

--- a/tools/mcp-server/src/tools/workflow.test.ts
+++ b/tools/mcp-server/src/tools/workflow.test.ts
@@ -1,0 +1,189 @@
+/**
+ * End-to-end workflow eval for MCP tools.
+ *
+ * Simulates what an AI agent would do: generate a keypair, create
+ * credentials, sign them, verify them, issue a payment request,
+ * verify it, create a receipt, and verify the receipt. If any step
+ * produces invalid output, the whole workflow fails.
+ */
+import {
+  createControllerCredential,
+  createDidKeyUri,
+  createJwtSigner,
+  createPaymentReceipt,
+  createSignedPaymentRequest,
+  generateKeypair,
+  getDidResolver,
+  keypairToJwk,
+  parseJwtCredential,
+  signCredential,
+  verifyParsedCredential,
+  verifyPaymentRequestToken,
+  verifyPaymentReceipt,
+  type DidUri,
+  type JwtString,
+  type PaymentRequestInit,
+} from "agentcommercekit"
+import { describe, expect, it } from "vitest"
+
+import { curveToAlg } from "../util"
+
+const resolver = getDidResolver()
+
+describe("full agent workflow", () => {
+  it("completes an identity + payment cycle end-to-end", async () => {
+    // 1. Generate keypairs for owner and agent
+    const ownerKeypair = await generateKeypair("secp256k1")
+    const agentKeypair = await generateKeypair("secp256k1")
+    const ownerDid = createDidKeyUri(ownerKeypair)
+    const agentDid = createDidKeyUri(agentKeypair)
+
+    // Verify JWK round-trip works (this is how MCP tools pass keys)
+    const ownerJwk = keypairToJwk(ownerKeypair)
+    expect(ownerJwk.crv).toBe("secp256k1")
+
+    // 2. Owner creates a controller credential for the agent
+    const credential = createControllerCredential({
+      subject: agentDid,
+      controller: ownerDid,
+    })
+
+    expect(credential.type).toContain("ControllerCredential")
+    expect(credential.credentialSubject.id).toBe(agentDid)
+
+    // 3. Owner signs the credential
+    const signedCredential = await signCredential(credential, {
+      did: ownerDid,
+      signer: createJwtSigner(ownerKeypair),
+      alg: curveToAlg(ownerKeypair.curve),
+    })
+
+    expect(signedCredential).toMatch(/^eyJ/)
+
+    // 4. Anyone can verify the signed credential
+    const parsed = await parseJwtCredential(signedCredential, resolver)
+    await verifyParsedCredential(parsed, { resolver })
+
+    expect(parsed.issuer).toEqual({ id: ownerDid })
+    expect(parsed.credentialSubject.controller).toBe(ownerDid)
+
+    // 5. Agent creates a payment request
+    const paymentInit: PaymentRequestInit = {
+      id: crypto.randomUUID(),
+      description: "API access fee",
+      paymentOptions: [
+        {
+          id: "option-eth",
+          amount: "0.001",
+          decimals: 18,
+          currency: "ETH",
+          recipient: "0x1234567890abcdef1234567890abcdef12345678",
+          network: "eip155:11155111",
+        },
+      ],
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+    }
+
+    const { paymentRequest, paymentRequestToken } =
+      await createSignedPaymentRequest(paymentInit, {
+        issuer: agentDid,
+        signer: createJwtSigner(agentKeypair),
+        algorithm: curveToAlg(agentKeypair.curve),
+      })
+
+    expect(paymentRequest.id).toBe(paymentInit.id)
+    expect(paymentRequestToken).toMatch(/^eyJ/)
+
+    // 6. Verify the payment request token
+    const { paymentRequest: verifiedRequest } = await verifyPaymentRequestToken(
+      paymentRequestToken,
+      { resolver },
+    )
+
+    expect(verifiedRequest.id).toBe(paymentInit.id)
+    expect(verifiedRequest.paymentOptions[0]!.currency).toBe("ETH")
+
+    // 7. After payment, agent issues a receipt
+    const receipt = createPaymentReceipt({
+      paymentRequestToken,
+      paymentOptionId: "option-eth",
+      issuer: agentDid,
+      payerDid: ownerDid,
+      metadata: { txHash: "0xabc123" },
+    })
+
+    expect(receipt.type).toContain("PaymentReceiptCredential")
+
+    // 8. Sign and verify the receipt
+    const signedReceipt = await signCredential(receipt, {
+      did: agentDid,
+      signer: createJwtSigner(agentKeypair),
+      alg: curveToAlg(agentKeypair.curve),
+    })
+
+    const { receipt: verifiedReceipt } = await verifyPaymentReceipt(
+      signedReceipt,
+      { resolver },
+    )
+
+    expect(verifiedReceipt.issuer).toEqual({ id: agentDid })
+  })
+
+  it("rejects a credential signed by the wrong key", async () => {
+    const ownerKeypair = await generateKeypair("secp256k1")
+    const attackerKeypair = await generateKeypair("secp256k1")
+    const ownerDid = createDidKeyUri(ownerKeypair)
+    const agentDid = createDidKeyUri(await generateKeypair("secp256k1"))
+
+    const credential = createControllerCredential({
+      subject: agentDid,
+      controller: ownerDid,
+    })
+
+    // Attacker signs with their own key but claims to be the owner.
+    // The DID resolver will find the owner's public key, which won't
+    // match the attacker's signature — rejection happens at parse time.
+    const signedByAttacker = await signCredential(credential, {
+      did: ownerDid,
+      signer: createJwtSigner(attackerKeypair),
+      alg: "ES256K",
+    })
+
+    await expect(
+      parseJwtCredential(signedByAttacker as JwtString, resolver),
+    ).rejects.toThrow()
+  })
+
+  it("rejects a payment request from an untrusted issuer", async () => {
+    const keypair = await generateKeypair("secp256k1")
+    const did = createDidKeyUri(keypair)
+
+    const { paymentRequestToken } = await createSignedPaymentRequest(
+      {
+        id: crypto.randomUUID(),
+        paymentOptions: [
+          {
+            id: "opt-1",
+            amount: 100,
+            decimals: 6,
+            currency: "USDC",
+            recipient: "0xrecipient",
+          },
+        ],
+      },
+      {
+        issuer: did,
+        signer: createJwtSigner(keypair),
+        algorithm: "ES256K",
+      },
+    )
+
+    // Valid token, but issuer doesn't match expected
+    await expect(
+      verifyPaymentRequestToken(paymentRequestToken, {
+        resolver,
+        issuer: "did:key:z6MkWrongIssuer",
+      }),
+    ).rejects.toThrow()
+  })
+})

--- a/tools/mcp-server/src/tools/workflow.test.ts
+++ b/tools/mcp-server/src/tools/workflow.test.ts
@@ -31,7 +31,7 @@ import { curveToAlg } from "../util"
 const resolver = getDidResolver()
 
 describe("full agent workflow", () => {
-  it("completes an identity + payment cycle end-to-end", async () => {
+  it("creates and verifies an identity + payment cycle end-to-end", async () => {
     // 1. Generate keypairs for owner and agent
     const ownerKeypair = await generateKeypair("secp256k1")
     const agentKeypair = await generateKeypair("secp256k1")
@@ -129,7 +129,7 @@ describe("full agent workflow", () => {
     expect(verifiedReceipt.issuer).toEqual({ id: agentDid })
   })
 
-  it("rejects a credential signed by the wrong key", async () => {
+  it("throws for a credential signed by the wrong key", async () => {
     const ownerKeypair = await generateKeypair("secp256k1")
     const attackerKeypair = await generateKeypair("secp256k1")
     const ownerDid = createDidKeyUri(ownerKeypair)
@@ -154,7 +154,7 @@ describe("full agent workflow", () => {
     ).rejects.toThrow()
   })
 
-  it("rejects a payment request from an untrusted issuer", async () => {
+  it("throws for a payment request from an untrusted issuer", async () => {
     const keypair = await generateKeypair("secp256k1")
     const did = createDidKeyUri(keypair)
 

--- a/tools/mcp-server/src/util.test.ts
+++ b/tools/mcp-server/src/util.test.ts
@@ -1,0 +1,97 @@
+import { generateKeypair, keypairToJwk } from "agentcommercekit"
+import { describe, expect, it } from "vitest"
+
+import { curveToAlg, err, keypairFromJwk, ok, verification } from "./util"
+
+describe("keypairFromJwk", () => {
+  it("reconstructs a secp256k1 keypair from its JWK", async () => {
+    const original = await generateKeypair("secp256k1")
+    const jwk = keypairToJwk(original)
+    const restored = keypairFromJwk(JSON.stringify(jwk))
+
+    expect(restored.curve).toBe("secp256k1")
+    expect(Buffer.from(restored.privateKey).toString("hex")).toBe(
+      Buffer.from(original.privateKey).toString("hex"),
+    )
+    expect(Buffer.from(restored.publicKey).toString("hex")).toBe(
+      Buffer.from(original.publicKey).toString("hex"),
+    )
+  })
+
+  it("reconstructs an Ed25519 keypair from its JWK", async () => {
+    const original = await generateKeypair("Ed25519")
+    const jwk = keypairToJwk(original)
+    const restored = keypairFromJwk(JSON.stringify(jwk))
+
+    expect(restored.curve).toBe("Ed25519")
+    expect(Buffer.from(restored.privateKey).toString("hex")).toBe(
+      Buffer.from(original.privateKey).toString("hex"),
+    )
+  })
+
+  it("throws on invalid JSON", () => {
+    expect(() => keypairFromJwk("not json")).toThrow()
+  })
+
+  it("throws on JWK missing required fields", () => {
+    expect(() => keypairFromJwk(JSON.stringify({ kty: "EC" }))).toThrow()
+  })
+})
+
+describe("curveToAlg", () => {
+  it("maps secp256k1 to ES256K", () => {
+    expect(curveToAlg("secp256k1")).toBe("ES256K")
+  })
+
+  it("maps secp256r1 to ES256", () => {
+    expect(curveToAlg("secp256r1")).toBe("ES256")
+  })
+
+  it("maps Ed25519 to EdDSA", () => {
+    expect(curveToAlg("Ed25519")).toBe("EdDSA")
+  })
+
+  it("throws on unsupported curve", () => {
+    expect(() => curveToAlg("P-384")).toThrow("Unsupported curve")
+  })
+})
+
+describe("response helpers", () => {
+  it("ok wraps data in MCP content format", () => {
+    const result = ok({ foo: "bar" })
+    expect(result.isError).toBeUndefined()
+    expect(result.content[0]!.type).toBe("text")
+    expect(JSON.parse((result.content[0] as { text: string }).text)).toEqual({
+      foo: "bar",
+    })
+  })
+
+  it("ok passes strings through without double-encoding", () => {
+    const result = ok("eyJhbGciOiJFUzI1NksifQ.test.sig")
+    expect((result.content[0] as { text: string }).text).toBe(
+      "eyJhbGciOiJFUzI1NksifQ.test.sig",
+    )
+  })
+
+  it("err wraps error message with isError flag", () => {
+    const result = err(new Error("something broke"))
+    expect(result.isError).toBe(true)
+    expect((result.content[0] as { text: string }).text).toBe(
+      "Error: something broke",
+    )
+  })
+
+  it("verification returns valid/invalid with data", () => {
+    const valid = verification(true, { score: 82 })
+    expect(JSON.parse((valid.content[0] as { text: string }).text)).toEqual({
+      valid: true,
+      score: 82,
+    })
+
+    const invalid = verification(false, { reason: "expired" })
+    expect(JSON.parse((invalid.content[0] as { text: string }).text)).toEqual({
+      valid: false,
+      reason: "expired",
+    })
+  })
+})

--- a/tools/mcp-server/src/util.test.ts
+++ b/tools/mcp-server/src/util.test.ts
@@ -36,6 +36,18 @@ describe("keypairFromJwk", () => {
   it("throws on JWK missing required fields", () => {
     expect(() => keypairFromJwk(JSON.stringify({ kty: "EC" }))).toThrow()
   })
+
+  it("throws on JSON array input", () => {
+    expect(() => keypairFromJwk("[1, 2, 3]")).toThrow("JWK must be a JSON object")
+  })
+
+  it("throws on JSON primitive input", () => {
+    expect(() => keypairFromJwk('"just a string"')).toThrow("JWK must be a JSON object")
+  })
+
+  it("throws on JSON null input", () => {
+    expect(() => keypairFromJwk("null")).toThrow("JWK must be a JSON object")
+  })
 })
 
 describe("curveToAlg", () => {

--- a/tools/mcp-server/src/util.ts
+++ b/tools/mcp-server/src/util.ts
@@ -20,6 +20,9 @@ export const resolver = getDidResolver()
  */
 export function keypairFromJwk(jwkJson: string): Keypair {
   const jwk = JSON.parse(jwkJson)
+  if (typeof jwk !== "object" || jwk === null || Array.isArray(jwk)) {
+    throw new Error("JWK must be a JSON object")
+  }
   return jwkToKeypair(jwk)
 }
 

--- a/tools/mcp-server/src/util.ts
+++ b/tools/mcp-server/src/util.ts
@@ -1,0 +1,69 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
+/**
+ * Shared utilities for MCP tools.
+ */
+import {
+  getDidResolver,
+  jwkToKeypair,
+  type JwtAlgorithm,
+  type Keypair,
+} from "agentcommercekit"
+
+/** Shared DID resolver instance. */
+export const resolver = getDidResolver()
+
+/**
+ * Reconstruct a Keypair from a JWK JSON string.
+ *
+ * Using JWK instead of raw hex + curve avoids the risk of curve mismatch —
+ * the JWK's `crv` field is always bundled with the key material.
+ */
+export function keypairFromJwk(jwkJson: string): Keypair {
+  const jwk = JSON.parse(jwkJson)
+  return jwkToKeypair(jwk)
+}
+
+/** Map a curve name to its JWT algorithm identifier. */
+export function curveToAlg(curve: string): JwtAlgorithm {
+  switch (curve) {
+    case "secp256k1":
+      return "ES256K"
+    case "secp256r1":
+      return "ES256"
+    case "Ed25519":
+      return "EdDSA"
+    default:
+      throw new Error(
+        `Unsupported curve: ${curve}. Use secp256k1, secp256r1, or Ed25519.`,
+      )
+  }
+}
+
+/** Return a successful MCP tool result with a JSON text response. */
+export function ok(data: unknown): CallToolResult {
+  return {
+    content: [
+      {
+        type: "text",
+        text: typeof data === "string" ? data : JSON.stringify(data, null, 2),
+      },
+    ],
+  }
+}
+
+/** Return an error MCP tool result. */
+export function err(error: unknown): CallToolResult {
+  const message = error instanceof Error ? error.message : String(error)
+  return {
+    content: [{ type: "text", text: `Error: ${message}` }],
+    isError: true,
+  }
+}
+
+/** Return a verification result (valid or invalid, never an error). */
+export function verification(
+  valid: boolean,
+  data: Record<string, unknown>,
+): CallToolResult {
+  return ok({ valid, ...data })
+}

--- a/tools/mcp-server/tsconfig.json
+++ b/tools/mcp-server/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/tools/mcp-server/vitest.config.ts
+++ b/tools/mcp-server/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    watch: false,
+  },
+})


### PR DESCRIPTION
Adds an MCP server that exposes ACK identity and payment operations as tools. Any MCP-compatible agent can generate keypairs, create and verify credentials, issue payment requests, and verify receipts.

## Tools

**Identity (ACK-ID)**
- `ack_create_controller_credential` — create ownership proof
- `ack_sign_credential` — sign a credential, returns JWT
- `ack_verify_credential` — verify signature, expiry, trusted issuers
- `ack_resolve_did` — resolve did:key, did:web, did:pkh

**Payments (ACK-Pay)**
- `ack_create_payment_request` — create signed payment request token
- `ack_verify_payment_request` — verify and parse a payment request JWT
- `ack_create_payment_receipt` — issue a receipt as a Verifiable Credential
- `ack_verify_payment_receipt` — verify a payment receipt

**Utility**
- `ack_generate_keypair` — generate secp256k1/secp256r1/Ed25519 keypair with DID

Signing tools accept JWK (returned by `ack_generate_keypair`) rather than raw private key + curve to prevent curve mismatches.

Uses stdio transport. MCP SDK pinned to 1.21.2 for zod 3 compatibility with the workspace.

Also added a workflow eval that exercises the full pipeline end-to-end:

- Generate keypairs for owner and agent
- Create a controller credential, sign it, verify it
- Create a payment request, sign it, verify it
- Issue a payment receipt, sign it, verify it
- Reject a credential signed by the wrong key
- Reject a payment request from an untrusted issuer

Figured if we're shipping MCP tools we should prove the whole cycle actually works.

## Test plan

- [x] 20 tests across 4 files — unit tests, integration round-trips, workflow eval
- [x] Smoke tested: server initializes, lists all 9 tools via MCP handshake
- [x] `pnpm run check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MCP server CLI/runtime with tools to create, sign, verify credentials; resolve DIDs; create/verify payment requests and receipts; and generate keypairs across multiple curves.
* **Tests**
  * Added unit and end-to-end tests covering credential and payment flows, signing/verification, keypair↔JWK conversions, algorithm mappings, and utility response helpers.
* **Chores**
  * Added local TypeScript and test configurations plus npm scripts for type checking, running, cleaning, and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**AI Disclosure:** This PR was developed with assistance from Claude Code (Claude Opus).