### PR TITLE
docs: add editUrl to enable "Edit this page on GitHub" link

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -26,6 +26,7 @@
       "keywords": "Agent Commerce Kit, ACK, Agent Commerce, Agentic Commerce, AI Agents, AI Commerce, AI Payments, AI Identity, AI Agentic Commerce, AI Agentic Payments, AI Agentic Identity"
     }
   },
+  "editUrl": "https://github.com/agentcommercekit/ack/edit/main/docs/",
   "navigation": {
     "tabs": [
       {


### PR DESCRIPTION
Adds the `editUrl` property to the root of the Mintlify configuration (`docs/docs.json`). This will display an "Edit this page on GitHub" link at the bottom of every documentation page, allowing readers to directly suggest improvements or fix typos.

The URL points to the `main` branch of the original repository: https://github.com/agentcommercekit/ack/edit/main/docs/

This change improves contribution UX and follows the standard practice for Mintlify-based documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a direct link to edit documentation on GitHub.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentcommercekit/ack/pull/85)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->