### PR TITLE
docs: remove duplicate H1 heading on versioning page

### DIFF
--- a/docs/resources/versioning.mdx
+++ b/docs/resources/versioning.mdx
@@ -3,8 +3,6 @@ title: Versioning
 description: How ACK protocol versions are managed and identified.
 ---
 
-# Versioning
-
 The Agent Commerce Kit (ACK) specifications as a whole use string-based version identifiers following the format `YYYY-MM-DD`. This date indicates when the last set of backwards-incompatible changes were introduced to the core protocols (ACK-ID or ACK-Pay).
 
 <Info>


### PR DESCRIPTION
## Fix duplicate H1 heading

This removes the markdown H1 heading `# Versioning` because the page already has a "title" in the frontmatter. 
Other pages like "Contributing" follow this pattern.