### PR TITLE
fix(ack-pay): validate receipt payment option

### DIFF
--- a/.changeset/validate-receipt-payment-option.md
+++ b/.changeset/validate-receipt-payment-option.md
@@ -1,0 +1,16 @@
+---
+"@agentcommercekit/ack-pay": patch
+---
+
+Validate that a PaymentReceipt's `paymentOptionId` matches an option offered by
+the verified Payment Request token.
+
+A receipt proves a `paymentRequestToken` and a selected `paymentOptionId`, but
+verification did not bind that selection back to an option actually offered by
+the request. `verifyPaymentReceipt` now rejects a receipt whose
+`paymentOptionId` is not present in the verified request's `paymentOptions`. The
+check reads from the proof-decoded credential, so it cannot be bypassed by
+mutating the outer object on the parsed-credential input path.
+
+Introduces `InvalidPaymentReceiptError` so callers can catch receipt-level
+validation failures explicitly.

--- a/packages/ack-pay/src/errors.ts
+++ b/packages/ack-pay/src/errors.ts
@@ -7,3 +7,10 @@ export class InvalidPaymentRequestTokenError extends Error {
     this.name = "InvalidPaymentRequestTokenError"
   }
 }
+
+export class InvalidPaymentReceiptError extends Error {
+  constructor(message = "Invalid payment receipt", options?: ErrorOptions) {
+    super(message, options)
+    this.name = "InvalidPaymentReceiptError"
+  }
+}

--- a/packages/ack-pay/src/verify-payment-receipt.test.ts
+++ b/packages/ack-pay/src/verify-payment-receipt.test.ts
@@ -23,7 +23,10 @@ import { beforeEach, describe, expect, it } from "vitest"
 
 import { createPaymentReceipt } from "./create-payment-receipt"
 import { createSignedPaymentRequest } from "./create-signed-payment-request"
-import { InvalidPaymentRequestTokenError } from "./errors"
+import {
+  InvalidPaymentReceiptError,
+  InvalidPaymentRequestTokenError,
+} from "./errors"
 import type { PaymentRequestInit } from "./payment-request"
 import { isPaymentReceiptCredential } from "./receipt-claim-verifier"
 import { verifyPaymentReceipt } from "./verify-payment-receipt"
@@ -173,6 +176,27 @@ describe("verifyPaymentReceipt()", () => {
         metadata: evidenceMetadata,
       },
     })
+  })
+
+  it("throws when the receipt payment option is not in the payment request", async () => {
+    const mismatchedReceipt = createPaymentReceipt({
+      paymentRequestToken,
+      paymentOptionId: "missing-payment-option-id",
+      issuer: receiptIssuerDid,
+      payerDid: createDidPkhUri(
+        "eip155:84532",
+        "0x7B3D8F2E1C9A4B5D6E7F8A9B0C1D2E3F4A5B6C",
+      ),
+    })
+
+    const mismatchedReceiptJwt = await signCredential(mismatchedReceipt, {
+      did: receiptIssuerDid,
+      signer: createJwtSigner(receiptIssuerKeypair),
+    })
+
+    await expect(
+      verifyPaymentReceipt(mismatchedReceiptJwt, { resolver }),
+    ).rejects.toThrow(InvalidPaymentReceiptError)
   })
 
   it("throws for an invalid JWT receipt", async () => {

--- a/packages/ack-pay/src/verify-payment-receipt.ts
+++ b/packages/ack-pay/src/verify-payment-receipt.ts
@@ -10,6 +10,7 @@ import {
   type W3CCredential,
 } from "@agentcommercekit/vc"
 
+import { InvalidPaymentReceiptError } from "./errors"
 import type { PaymentRequest } from "./payment-request"
 import {
   getReceiptClaimVerifier,
@@ -127,6 +128,20 @@ export async function verifyPaymentReceipt(
       issuer: paymentRequestIssuer,
     },
   )
+
+  // Bind the receipt's selected option back to an option actually offered by
+  // the verified Payment Request. Reads from `verifiedReceipt` (proof-decoded),
+  // so a mutated outer credential cannot smuggle in an unoffered option.
+  const paymentOptionExists = paymentRequest.paymentOptions.some(
+    (paymentOption) =>
+      paymentOption.id === verifiedReceipt.credentialSubject.paymentOptionId,
+  )
+
+  if (!paymentOptionExists) {
+    throw new InvalidPaymentReceiptError(
+      "Receipt paymentOptionId does not match any payment option in the Payment Request token",
+    )
+  }
 
   return {
     receipt: verifiedReceipt,


### PR DESCRIPTION
## Summary

- Validate that a PaymentReceipt's `paymentOptionId` matches an option offered by the verified Payment Request token
- Add a dedicated `InvalidPaymentReceiptError` for receipt-level semantic failures
- Cover the mismatched-option case with a regression test
- Add a patch changeset for `@agentcommercekit/ack-pay`

## Why

A receipt proves a `paymentRequestToken` and a selected `paymentOptionId`, but verification did not bind that selection back to an option actually offered by the request. This keeps receipt proof semantics aligned with the payment options the request offered.

The binding check reads from the proof-decoded credential (`verifiedReceipt`, returned by `verifyParsedCredential`), so it cannot be bypassed by mutating the outer object on the parsed-credential input path. This builds on the trust-boundary work in #108 / the proof-binding changeset already on `main`.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run check` (build + format + types + lint + test) — all green, lint 0 warnings/0 errors
- `pnpm --filter @agentcommercekit/ack-pay test` — 35 passing

## AI Usage Disclosure

This contribution was AI-assisted (Codex CLI/app and Claude Opus). AI assistance was used for repository/docs navigation, understanding ACK context, and small edits/validation. The branch was rebased onto current `main` and the feature was rebuilt on top of main's proof-verified-receipt mechanism. I reviewed the final diff and take responsibility for the submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Receipt verification now rejects receipts when the receipt’s `paymentOptionId` doesn’t match an option in the verified payment request.
  * Receipt parsing from JWT proof now derives receipt fields from the signed proof to prevent bypass via mutated input.
* **Tests**
  * Added a negative test ensuring `verifyPaymentReceipt(...)` throws when the payment option is missing from the payment request.
* **Chores**
  * Patch release update, including a new exported `InvalidPaymentReceiptError` for callers to catch receipt validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->