### PR TITLE
docs(ack-pay): align receipt API examples

### DIFF
--- a/docs/ack-pay/receipt-verification.mdx
+++ b/docs/ack-pay/receipt-verification.mdx
@@ -23,7 +23,7 @@ _Example ACK Receipt Verifiable Credential:_
     "https://agentcommercekit.org/contexts/payment/v1" // Example ACK context
   ],
   "id": "urn:uuid:5c358383-1d93-4956-8d0c-6e41e4d29901", // Unique receipt ID
-  "type": ["VerifiableCredential", "ACKPaymentReceipt"],
+  "type": ["VerifiableCredential", "PaymentReceiptCredential"],
   "issuer": "did:web:receipts.example.com", // DID of the trusted Receipt Service
   "issuanceDate": "2025-04-04T14:22:18Z",
   "credentialSubject": {

--- a/packages/ack-pay/README.md
+++ b/packages/ack-pay/README.md
@@ -77,23 +77,23 @@ import { getDidResolver } from "@agentcommercekit/did"
 
 const verified = await verifyPaymentReceipt(receipt, {
   resolver: getDidResolver(),
-  trustedIssuers: ["did:web:merchant.example.com"],
+  trustedReceiptIssuers: ["did:web:receipt-service.example.com"],
 })
 ```
 
 ### Type Guards for Validation
 
 ```ts
-import { isPaymentRequest } from "@agentcommercekit/ack-pay"
+import {
+  isPaymentReceiptCredential,
+  isPaymentRequest,
+} from "@agentcommercekit/ack-pay"
 
 // Check if a value is a valid payment request
 isPaymentRequest(unknownObject)
 
 // Check if a credential is specifically a payment receipt credential
 isPaymentReceiptCredential(credential)
-
-// Check if a credential subject has the payment receipt claim structure
-isPaymentReceiptClaim(credential.credentialSubject)
 ```
 
 ## API Reference


### PR DESCRIPTION
## Summary

- update the ACK-Pay README receipt verification example to use `trustedReceiptIssuers`, matching the exported `verifyPaymentReceipt` options
- remove the README reference to unexported `isPaymentReceiptClaim` and import the exported receipt credential guard
- align the receipt verification docs example with the SDK credential type `PaymentReceiptCredential`

## Why

The README currently shows `trustedIssuers`, but `verifyPaymentReceipt` accepts `trustedReceiptIssuers`. It also references `isPaymentReceiptClaim`, which is internal to `receipt-claim-verifier.ts` and is not exported from `@agentcommercekit/ack-pay`.

## Verification

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm check:format`
- `git diff --check`
- `corepack pnpm --filter @agentcommercekit/ack-pay check:types` initially failed because workspace package exports resolve from built `dist` outputs
- `corepack pnpm --filter @agentcommercekit/ack-pay... build`
- `corepack pnpm --filter @agentcommercekit/ack-pay check:types`

## Notes

This is docs-only and avoids the receipt verification logic changed in #88.

## AI Usage Disclosure
This contribution was AI-assisted using Codex CLI and the Codex app. AI assistance was used for repository/docs navigation, understanding ACK/Catena context, identifying relevant issues or contribution areas, and assisting with small edits/validation. I reviewed the final diff and take responsibility for the submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated payment receipt verification examples to reflect current credential taxonomy (`PaymentReceiptCredential`) and trust configuration patterns with `trustedReceiptIssuers`
* Refreshed type guard validation examples to showcase the latest utilities for validating payment receipts and requests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentcommercekit/ack/pull/89)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->