### PR TITLE
demo(payments): enforce policy before signing

### DIFF
--- a/demos/payments/README.md
+++ b/demos/payments/README.md
@@ -40,6 +40,10 @@ happens before execution or signing:
 - unknown recipient: return `approval_required`
 - amount above the autonomous spend limit: deny before payment execution
 
+The demo allowlist is based on the configured server identity, not the issuer
+claimed by each incoming Payment Request token. A real Payment Service should
+load this allowlist from operator-controlled configuration.
+
 ## Demo Video
 
 <p align="center">

--- a/demos/payments/README.md
+++ b/demos/payments/README.md
@@ -38,7 +38,20 @@ happens before execution or signing:
 
 - known low-value recipient: continue automatically
 - unknown recipient: return `approval_required`
-- amount above the autonomous spend limit: deny before payment execution
+- amount above the illustrative per-transaction cap: deny before payment
+  execution
+
+The per-currency cap is expressed in each currency's smallest subunit, so a
+single flat threshold is never compared across currencies with different
+decimals (e.g. USD at 2dp vs USDC at 6dp). Currencies without a configured
+limit are denied outright.
+
+> [!IMPORTANT]
+> The amount check is an **illustrative per-transaction cap, not a real spend
+> control.** A per-transaction limit is trivially defeated by splitting one
+> payment into many smaller ones (`cap × N`). A production policy needs a
+> cumulative and/or rate-limited budget (e.g. per-payer spend over a rolling
+> window), not just a single-transaction threshold.
 
 The demo allowlist is based on the configured server identity, not the issuer
 claimed by each incoming Payment Request token. A real Payment Service should

--- a/demos/payments/README.md
+++ b/demos/payments/README.md
@@ -20,8 +20,25 @@ This interactive command-line demo showcases a common use case: the **Server-Ini
   - Handling currency conversions.
   - Integrating compliance checks (KYC/AML).
   - Facilitating complex payment routing.
+  - Enforcing local payment policy before returning an execution URL or signing a receipt-service payload.
 
 You can learn more about the full ACK-Pay protocol at [www.agentcommercekit.com](https://www.agentcommercekit.com).
+
+## Policy-before-signing example
+
+The Stripe Payment Service path includes a tiny local policy guard in
+`src/payment-policy.ts`. The guard runs after the Payment Request token and
+payment option are verified, but before the demo returns a payment URL or signs
+the payload that asks the Receipt Service to issue a receipt.
+
+This is an example pattern, not a normative ACK-Pay policy engine. Production
+Payment Services should replace it with their own owner, risk, compliance, or
+human-approval system. The important safety boundary is that policy enforcement
+happens before execution or signing:
+
+- known low-value recipient: continue automatically
+- unknown recipient: return `approval_required`
+- amount above the autonomous spend limit: deny before payment execution
 
 ## Demo Video
 

--- a/demos/payments/src/payment-policy.test.ts
+++ b/demos/payments/src/payment-policy.test.ts
@@ -5,7 +5,7 @@ import { evaluatePaymentPolicy } from "./payment-policy"
 const basePaymentOption = {
   id: "base-usdc",
   amount: 100,
-  decimals: 2,
+  decimals: 6,
   currency: "USDC",
   recipient: "did:example:merchant",
 }
@@ -14,8 +14,22 @@ describe("evaluatePaymentPolicy", () => {
   it("approves below-threshold payments to allowed recipients", () => {
     const decision = evaluatePaymentPolicy(basePaymentOption, {
       allowedRecipients: [basePaymentOption.recipient],
-      maxAutonomousAmount: 1_000,
+      maxAutonomousAmount: { USDC: 1_000n },
     })
+
+    expect(decision).toEqual({
+      status: "approved",
+    })
+  })
+
+  it("approves string subunit amounts within the limit", () => {
+    const decision = evaluatePaymentPolicy(
+      { ...basePaymentOption, amount: "50000" },
+      {
+        allowedRecipients: [basePaymentOption.recipient],
+        maxAutonomousAmount: { USDC: 5_000_000n },
+      },
+    )
 
     expect(decision).toEqual({
       status: "approved",
@@ -25,7 +39,7 @@ describe("evaluatePaymentPolicy", () => {
   it("does not approve self-asserted recipients without an allowlist", () => {
     const decision = evaluatePaymentPolicy(basePaymentOption, {
       allowedRecipients: [],
-      maxAutonomousAmount: 1_000,
+      maxAutonomousAmount: { USDC: 1_000n },
     })
 
     expect(decision).toEqual({
@@ -37,7 +51,7 @@ describe("evaluatePaymentPolicy", () => {
   it("requires approval before execution for unknown recipients", () => {
     const decision = evaluatePaymentPolicy(basePaymentOption, {
       allowedRecipients: ["did:example:trusted-merchant"],
-      maxAutonomousAmount: 1_000,
+      maxAutonomousAmount: { USDC: 1_000n },
     })
 
     expect(decision).toEqual({
@@ -54,13 +68,80 @@ describe("evaluatePaymentPolicy", () => {
       },
       {
         allowedRecipients: [basePaymentOption.recipient],
-        maxAutonomousAmount: 1_000,
+        maxAutonomousAmount: { USDC: 1_000n },
       },
     )
 
     expect(decision).toEqual({
       status: "denied",
       reason: "Payment amount exceeds the autonomous spend limit",
+    })
+  })
+
+  it("applies the per-currency limit in the currency's own subunits", () => {
+    const policy = {
+      allowedRecipients: [basePaymentOption.recipient],
+      // 5.00 USD (2dp) and 5.000000 USDC (6dp) — same value, different subunits
+      maxAutonomousAmount: { USD: 500n, USDC: 5_000_000n },
+    }
+
+    // 4.00 USD is below the USD limit
+    expect(
+      evaluatePaymentPolicy(
+        { ...basePaymentOption, amount: 400, decimals: 2, currency: "USD" },
+        policy,
+      ),
+    ).toEqual({ status: "approved" })
+
+    // The same 400 subunits in USDC (0.0004) is also below the USDC limit,
+    // confirming each currency is bounded by its own threshold
+    expect(
+      evaluatePaymentPolicy({ ...basePaymentOption, amount: 400 }, policy),
+    ).toEqual({ status: "approved" })
+  })
+
+  it("denies currencies with no configured limit", () => {
+    const decision = evaluatePaymentPolicy(
+      { ...basePaymentOption, currency: "SOL", decimals: 9 },
+      {
+        allowedRecipients: [basePaymentOption.recipient],
+        maxAutonomousAmount: { USDC: 1_000n },
+      },
+    )
+
+    expect(decision).toEqual({
+      status: "denied",
+      reason: "No autonomous spend limit configured for currency SOL",
+    })
+  })
+
+  it("denies non-positive amounts", () => {
+    const decision = evaluatePaymentPolicy(
+      { ...basePaymentOption, amount: 0 },
+      {
+        allowedRecipients: [basePaymentOption.recipient],
+        maxAutonomousAmount: { USDC: 1_000n },
+      },
+    )
+
+    expect(decision).toEqual({
+      status: "denied",
+      reason: "Payment amount must be greater than zero",
+    })
+  })
+
+  it("denies fractional or malformed amounts the schema permits as strings", () => {
+    const decision = evaluatePaymentPolicy(
+      { ...basePaymentOption, amount: "1.5" },
+      {
+        allowedRecipients: [basePaymentOption.recipient],
+        maxAutonomousAmount: { USDC: 1_000n },
+      },
+    )
+
+    expect(decision).toEqual({
+      status: "denied",
+      reason: "Payment amount must be a positive integer in subunits",
     })
   })
 })

--- a/demos/payments/src/payment-policy.test.ts
+++ b/demos/payments/src/payment-policy.test.ts
@@ -130,6 +130,21 @@ describe("evaluatePaymentPolicy", () => {
     })
   })
 
+  it("denies currencies matching inherited prototype keys", () => {
+    const decision = evaluatePaymentPolicy(
+      { ...basePaymentOption, currency: "constructor" },
+      {
+        allowedRecipients: [basePaymentOption.recipient],
+        maxAutonomousAmount: { USDC: 1_000n },
+      },
+    )
+
+    expect(decision).toEqual({
+      status: "denied",
+      reason: "No autonomous spend limit configured for currency constructor",
+    })
+  })
+
   it("denies fractional or malformed amounts the schema permits as strings", () => {
     const decision = evaluatePaymentPolicy(
       { ...basePaymentOption, amount: "1.5" },

--- a/demos/payments/src/payment-policy.test.ts
+++ b/demos/payments/src/payment-policy.test.ts
@@ -22,15 +22,15 @@ describe("evaluatePaymentPolicy", () => {
     })
   })
 
-  it("approves payments back to the trusted request issuer", () => {
+  it("does not approve self-asserted recipients without an allowlist", () => {
     const decision = evaluatePaymentPolicy(basePaymentOption, {
       allowedRecipients: [],
       maxAutonomousAmount: 1_000,
-      trustedRequestIssuer: basePaymentOption.recipient,
     })
 
     expect(decision).toEqual({
-      status: "approved",
+      status: "approval_required",
+      reason: "Recipient is not on the autonomous payment allowlist",
     })
   })
 

--- a/demos/payments/src/payment-policy.test.ts
+++ b/demos/payments/src/payment-policy.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest"
+
+import { evaluatePaymentPolicy } from "./payment-policy"
+
+const basePaymentOption = {
+  id: "base-usdc",
+  amount: 100,
+  decimals: 2,
+  currency: "USDC",
+  recipient: "did:example:merchant",
+}
+
+describe("evaluatePaymentPolicy", () => {
+  it("approves below-threshold payments to allowed recipients", () => {
+    const decision = evaluatePaymentPolicy(basePaymentOption, {
+      allowedRecipients: [basePaymentOption.recipient],
+      maxAutonomousAmount: 1_000,
+    })
+
+    expect(decision).toEqual({
+      status: "approved",
+    })
+  })
+
+  it("approves payments back to the trusted request issuer", () => {
+    const decision = evaluatePaymentPolicy(basePaymentOption, {
+      allowedRecipients: [],
+      maxAutonomousAmount: 1_000,
+      trustedRequestIssuer: basePaymentOption.recipient,
+    })
+
+    expect(decision).toEqual({
+      status: "approved",
+    })
+  })
+
+  it("requires approval before execution for unknown recipients", () => {
+    const decision = evaluatePaymentPolicy(basePaymentOption, {
+      allowedRecipients: ["did:example:trusted-merchant"],
+      maxAutonomousAmount: 1_000,
+    })
+
+    expect(decision).toEqual({
+      status: "approval_required",
+      reason: "Recipient is not on the autonomous payment allowlist",
+    })
+  })
+
+  it("denies payments above the autonomous spend limit", () => {
+    const decision = evaluatePaymentPolicy(
+      {
+        ...basePaymentOption,
+        amount: 10_000,
+      },
+      {
+        allowedRecipients: [basePaymentOption.recipient],
+        maxAutonomousAmount: 1_000,
+      },
+    )
+
+    expect(decision).toEqual({
+      status: "denied",
+      reason: "Payment amount exceeds the autonomous spend limit",
+    })
+  })
+})

--- a/demos/payments/src/payment-policy.ts
+++ b/demos/payments/src/payment-policy.ts
@@ -11,28 +11,62 @@ export type PaymentPolicyDecision =
 
 export interface PaymentPolicy {
   allowedRecipients: readonly string[]
-  maxAutonomousAmount: number
+  /**
+   * Per-transaction autonomous spend limits, expressed in each currency's
+   * smallest subunit (matching `PaymentOption.amount`) and keyed by currency
+   * code. Keeping the limit per-currency avoids comparing a single flat
+   * threshold across currencies with different decimals (e.g. USD at 2dp vs
+   * USDC at 6dp). A currency with no configured limit is denied.
+   *
+   * NOTE: this is a per-transaction cap only, not a cumulative or rate budget.
+   * See the demo README — a real spend control needs windowed/cumulative
+   * limits, since a per-transaction cap is trivially split-gameable.
+   */
+  maxAutonomousAmount: Readonly<Record<string, bigint>>
 }
 
 export const demoPaymentPolicy: PaymentPolicy = {
   allowedRecipients: [],
-  maxAutonomousAmount: 1_000_000,
+  maxAutonomousAmount: {
+    // 5.00 USD (2 decimals) and 5.000000 USDC (6 decimals)
+    USD: 500n,
+    USDC: 5_000_000n,
+  },
 }
 
 export function evaluatePaymentPolicy(
   paymentOption: PaymentOption,
   policy: PaymentPolicy = demoPaymentPolicy,
 ): PaymentPolicyDecision {
-  const amount = Number(paymentOption.amount)
-
-  if (!Number.isFinite(amount)) {
+  let amount: bigint
+  try {
+    // Follows the repo-wide BigInt money convention (see receipt-service.ts,
+    // index.ts). `BigInt()` throws on fractional/malformed amounts the
+    // ACK-Pay schema's string branch otherwise permits.
+    amount = BigInt(paymentOption.amount)
+  } catch {
     return {
       status: "denied",
-      reason: "Payment amount must be a finite number",
+      reason: "Payment amount must be a positive integer in subunits",
     }
   }
 
-  if (amount > policy.maxAutonomousAmount) {
+  if (amount <= 0n) {
+    return {
+      status: "denied",
+      reason: "Payment amount must be greater than zero",
+    }
+  }
+
+  const limit = policy.maxAutonomousAmount[paymentOption.currency]
+  if (limit === undefined) {
+    return {
+      status: "denied",
+      reason: `No autonomous spend limit configured for currency ${paymentOption.currency}`,
+    }
+  }
+
+  if (amount > limit) {
     return {
       status: "denied",
       reason: "Payment amount exceeds the autonomous spend limit",
@@ -48,16 +82,5 @@ export function evaluatePaymentPolicy(
 
   return {
     status: "approved",
-  }
-}
-
-export function assertPaymentPolicyApproved(
-  paymentOption: PaymentOption,
-  policy: PaymentPolicy = demoPaymentPolicy,
-) {
-  const decision = evaluatePaymentPolicy(paymentOption, policy)
-
-  if (decision.status !== "approved") {
-    throw new Error(decision.reason)
   }
 }

--- a/demos/payments/src/payment-policy.ts
+++ b/demos/payments/src/payment-policy.ts
@@ -58,8 +58,16 @@ export function evaluatePaymentPolicy(
     }
   }
 
-  const limit = policy.maxAutonomousAmount[paymentOption.currency]
-  if (limit === undefined) {
+  // `currency` is an unconstrained wire string, so guard against inherited
+  // prototype keys (e.g. "constructor", "toString") that would otherwise
+  // resolve to a non-bigint value and slip past the comparison below.
+  const limit = Object.prototype.hasOwnProperty.call(
+    policy.maxAutonomousAmount,
+    paymentOption.currency,
+  )
+    ? policy.maxAutonomousAmount[paymentOption.currency]
+    : undefined
+  if (typeof limit !== "bigint") {
     return {
       status: "denied",
       reason: `No autonomous spend limit configured for currency ${paymentOption.currency}`,

--- a/demos/payments/src/payment-policy.ts
+++ b/demos/payments/src/payment-policy.ts
@@ -12,7 +12,6 @@ export type PaymentPolicyDecision =
 export interface PaymentPolicy {
   allowedRecipients: readonly string[]
   maxAutonomousAmount: number
-  trustedRequestIssuer?: string
 }
 
 export const demoPaymentPolicy: PaymentPolicy = {
@@ -40,10 +39,7 @@ export function evaluatePaymentPolicy(
     }
   }
 
-  if (
-    !policy.allowedRecipients.includes(paymentOption.recipient) &&
-    paymentOption.recipient !== policy.trustedRequestIssuer
-  ) {
+  if (!policy.allowedRecipients.includes(paymentOption.recipient)) {
     return {
       status: "approval_required",
       reason: "Recipient is not on the autonomous payment allowlist",

--- a/demos/payments/src/payment-policy.ts
+++ b/demos/payments/src/payment-policy.ts
@@ -1,0 +1,67 @@
+import type { PaymentOption } from "agentcommercekit"
+
+export type PaymentPolicyDecision =
+  | {
+      status: "approved"
+    }
+  | {
+      status: "approval_required" | "denied"
+      reason: string
+    }
+
+export interface PaymentPolicy {
+  allowedRecipients: readonly string[]
+  maxAutonomousAmount: number
+  trustedRequestIssuer?: string
+}
+
+export const demoPaymentPolicy: PaymentPolicy = {
+  allowedRecipients: [],
+  maxAutonomousAmount: 1_000_000,
+}
+
+export function evaluatePaymentPolicy(
+  paymentOption: PaymentOption,
+  policy: PaymentPolicy = demoPaymentPolicy,
+): PaymentPolicyDecision {
+  const amount = Number(paymentOption.amount)
+
+  if (!Number.isFinite(amount)) {
+    return {
+      status: "denied",
+      reason: "Payment amount must be a finite number",
+    }
+  }
+
+  if (amount > policy.maxAutonomousAmount) {
+    return {
+      status: "denied",
+      reason: "Payment amount exceeds the autonomous spend limit",
+    }
+  }
+
+  if (
+    !policy.allowedRecipients.includes(paymentOption.recipient) &&
+    paymentOption.recipient !== policy.trustedRequestIssuer
+  ) {
+    return {
+      status: "approval_required",
+      reason: "Recipient is not on the autonomous payment allowlist",
+    }
+  }
+
+  return {
+    status: "approved",
+  }
+}
+
+export function assertPaymentPolicyApproved(
+  paymentOption: PaymentOption,
+  policy: PaymentPolicy = demoPaymentPolicy,
+) {
+  const decision = evaluatePaymentPolicy(paymentOption, policy)
+
+  if (decision.status !== "approved") {
+    throw new Error(decision.reason)
+  }
+}

--- a/demos/payments/src/payment-service.ts
+++ b/demos/payments/src/payment-service.ts
@@ -16,7 +16,7 @@ import { HTTPException } from "hono/http-exception"
 import * as v from "valibot"
 
 import { PAYMENT_SERVICE_URL } from "./constants"
-import { evaluatePaymentPolicy } from "./payment-policy"
+import { demoPaymentPolicy, evaluatePaymentPolicy } from "./payment-policy"
 import { getKeypairInfo } from "./utils/keypair-info"
 
 const app = new Hono<Env>()
@@ -131,7 +131,7 @@ async function validatePaymentOption(
   const didResolver = getDidResolver()
 
   log(colors.dim(`${name} Verifying payment request token...`))
-  const { paymentRequest, parsed } = await verifyPaymentRequestToken(
+  const { paymentRequest } = await verifyPaymentRequestToken(
     paymentRequestToken,
     {
       resolver: didResolver,
@@ -153,7 +153,6 @@ async function validatePaymentOption(
   return {
     paymentRequest,
     paymentOption,
-    parsed,
   }
 }
 
@@ -164,8 +163,8 @@ function enforcePaymentPolicy(
   allowedRecipients: readonly string[],
 ) {
   const decision = evaluatePaymentPolicy(paymentOption, {
+    ...demoPaymentPolicy,
     allowedRecipients,
-    maxAutonomousAmount: 1_000_000,
   })
 
   if (decision.status !== "approved") {

--- a/demos/payments/src/payment-service.ts
+++ b/demos/payments/src/payment-service.ts
@@ -16,6 +16,7 @@ import { HTTPException } from "hono/http-exception"
 import * as v from "valibot"
 
 import { PAYMENT_SERVICE_URL } from "./constants"
+import { evaluatePaymentPolicy } from "./payment-policy"
 import { getKeypairInfo } from "./utils/keypair-info"
 
 const app = new Hono<Env>()
@@ -39,8 +40,13 @@ app.post("/", async (c): Promise<TypedResponse<{ paymentUrl: string }>> => {
     await c.req.json(),
   )
 
-  // Verify the payment request token and payment option are valid
-  await validatePaymentOption(paymentOptionId, paymentRequestToken)
+  // Verify the payment request token and payment option are valid before
+  // returning an execution URL.
+  const { paymentOption, parsed } = await validatePaymentOption(
+    paymentOptionId,
+    paymentRequestToken,
+  )
+  enforcePaymentPolicy(paymentOption, parsed.issuer)
 
   log(colors.dim(`${name} Generating Stripe payment URL ...`))
 
@@ -73,7 +79,7 @@ app.post(
     )
 
     // Verify the payment request token and payment option are valid
-    const { paymentOption } = await validatePaymentOption(
+    const { paymentOption, parsed } = await validatePaymentOption(
       paymentOptionId,
       paymentRequestToken,
     )
@@ -81,6 +87,7 @@ app.post(
     if (!receiptServiceUrl) {
       throw new Error(errorMessage("Receipt service URL is required"))
     }
+    enforcePaymentPolicy(paymentOption, parsed.issuer)
 
     const payload = {
       paymentRequestToken,
@@ -124,7 +131,7 @@ async function validatePaymentOption(
   const didResolver = getDidResolver()
 
   log(colors.dim(`${name} Verifying payment request token...`))
-  const { paymentRequest } = await verifyPaymentRequestToken(
+  const { paymentRequest, parsed } = await verifyPaymentRequestToken(
     paymentRequestToken,
     {
       resolver: didResolver,
@@ -146,6 +153,27 @@ async function validatePaymentOption(
   return {
     paymentRequest,
     paymentOption,
+    parsed,
+  }
+}
+
+function enforcePaymentPolicy(
+  paymentOption: Awaited<
+    ReturnType<typeof validatePaymentOption>
+  >["paymentOption"],
+  trustedRequestIssuer?: string,
+) {
+  const decision = evaluatePaymentPolicy(paymentOption, {
+    allowedRecipients: [],
+    maxAutonomousAmount: 1_000_000,
+    trustedRequestIssuer,
+  })
+
+  if (decision.status !== "approved") {
+    log(errorMessage(`${name} ${decision.reason}`))
+    throw new HTTPException(decision.status === "denied" ? 403 : 409, {
+      message: decision.reason,
+    })
   }
 }
 

--- a/demos/payments/src/payment-service.ts
+++ b/demos/payments/src/payment-service.ts
@@ -10,7 +10,7 @@ import {
   type Verifiable,
 } from "agentcommercekit"
 import { jwtStringSchema } from "agentcommercekit/schemas/valibot"
-import { Hono, type Env, type TypedResponse } from "hono"
+import { Hono, type Context, type Env, type TypedResponse } from "hono"
 import { env } from "hono/adapter"
 import { HTTPException } from "hono/http-exception"
 import * as v from "valibot"
@@ -42,11 +42,11 @@ app.post("/", async (c): Promise<TypedResponse<{ paymentUrl: string }>> => {
 
   // Verify the payment request token and payment option are valid before
   // returning an execution URL.
-  const { paymentOption, parsed } = await validatePaymentOption(
+  const { paymentOption } = await validatePaymentOption(
     paymentOptionId,
     paymentRequestToken,
   )
-  enforcePaymentPolicy(paymentOption, parsed.issuer)
+  enforcePaymentPolicy(paymentOption, await getTrustedRecipients(c))
 
   log(colors.dim(`${name} Generating Stripe payment URL ...`))
 
@@ -79,7 +79,7 @@ app.post(
     )
 
     // Verify the payment request token and payment option are valid
-    const { paymentOption, parsed } = await validatePaymentOption(
+    const { paymentOption } = await validatePaymentOption(
       paymentOptionId,
       paymentRequestToken,
     )
@@ -87,7 +87,7 @@ app.post(
     if (!receiptServiceUrl) {
       throw new Error(errorMessage("Receipt service URL is required"))
     }
-    enforcePaymentPolicy(paymentOption, parsed.issuer)
+    enforcePaymentPolicy(paymentOption, await getTrustedRecipients(c))
 
     const payload = {
       paymentRequestToken,
@@ -161,12 +161,11 @@ function enforcePaymentPolicy(
   paymentOption: Awaited<
     ReturnType<typeof validatePaymentOption>
   >["paymentOption"],
-  trustedRequestIssuer?: string,
+  allowedRecipients: readonly string[],
 ) {
   const decision = evaluatePaymentPolicy(paymentOption, {
-    allowedRecipients: [],
+    allowedRecipients,
     maxAutonomousAmount: 1_000_000,
-    trustedRequestIssuer,
   })
 
   if (decision.status !== "approved") {
@@ -175,6 +174,11 @@ function enforcePaymentPolicy(
       message: decision.reason,
     })
   }
+}
+
+async function getTrustedRecipients(c: Context<Env>) {
+  const serverIdentity = await getKeypairInfo(env(c).SERVER_PRIVATE_KEY_HEX)
+  return [serverIdentity.did]
 }
 
 serve({


### PR DESCRIPTION
## Summary
- Add a tiny local payment policy guard for the payments demo
- Enforce policy after payment request verification but before returning an execution URL or signing the receipt-service payload
- Cover approved, approval-required, and denied policy outcomes with focused tests
- Document that this is an example pattern, not a normative ACK-Pay policy engine

Fixes #91

## Review follow-ups (addressed)
- Money handling now follows the repo-wide BigInt convention (`BigInt(paymentOption.amount)`), with an explicit positive-integer guard so fractional/non-positive/empty amounts the schema permits are denied instead of passing policy.
- The autonomous spend limit is now a per-currency map keyed on currency code and expressed in each currency's subunits, so the threshold is coherent across USD (2dp) / USDC (6dp); currencies with no configured limit are denied.
- `demoPaymentPolicy` is now the single source of truth — `enforcePaymentPolicy` spreads it and overrides only `allowedRecipients`, dropping the hardcoded literal.
- README reworded to state plainly that the amount check is an illustrative per-transaction cap, not a real spend control (split-gameable without a cumulative/rate budget).
- Optional cleanups: removed the dead `parsed` value and the unused `assertPaymentPolicyApproved` export.
- Rebased onto latest `main`.

## Verification
- pnpm run build
- pnpm --filter ./demos/payments check:types
- pnpm --filter ./demos/payments exec vitest run
- pnpm exec oxfmt --check demos/payments/README.md demos/payments/src/payment-policy.ts demos/payments/src/payment-policy.test.ts demos/payments/src/payment-service.ts
- pnpm exec oxlint demos/payments/src/payment-policy.ts demos/payments/src/payment-service.ts demos/payments/src/payment-policy.test.ts
- git diff --check

## AI Usage Disclosure
This contribution was AI-assisted. Initial work used Codex CLI and the Codex app; the review follow-ups above were completed with Claude Opus. AI assistance was used for repository/docs navigation, understanding ACK/Catena context, identifying relevant issues or contribution areas, and assisting with small edits/validation. I reviewed the final diff and take responsibility for the submitted changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payments now enforce a policy-based approval flow that gates autonomous transactions, applies per-currency spending caps, and requires recipient approval before returning payment URLs or signing receipts.

* **Documentation**
  * Added a “policy-before-signing” example explaining approval outcomes, illustrative per-currency caps, and that the demo allowlist is derived from server identity.

* **Tests**
  * Added comprehensive tests covering approval, denial, malformed amounts, per-currency limits, and allowlist behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->