### PR TITLE
docs: add missing demo references for skyfire-kya and identity-a2a

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,18 @@ pnpm demo:e2e
 
 You can see the code for this demo in [`./demos/e2e`](./demos/e2e).
 
+### Skyfire KYA Demo
+
+This demo shows how [Skyfire](https://skyfire.xyz) KYA (Know Your Agent) tokens can work on top of ACK-ID's identity infrastructure, demonstrating how third-party agent identity systems can integrate with ACK.
+
+To use this demo, run the following command:
+
+```sh
+pnpm demo:skyfire-kya
+```
+
+You can see the code for this demo in [`./demos/skyfire-kya`](./demos/skyfire-kya).
+
 ## Example Services
 
 This repository contains several standalone services as example implementations of the ACK-ID and ACK-Pay protocols, using the `agentcommercekit` TypeScript SDK. These examples are located in the [`./examples`](./examples) directory.

--- a/demos/README.md
+++ b/demos/README.md
@@ -36,6 +36,26 @@ pnpm demo:e2e
 
 [View the code](./e2e)
 
+### Identity A2A demo
+
+An example of two A2A-compatible agents using ACK-ID to verify each other's identity, built on Google's A2A (Agent2Agent) protocol.
+
+```sh
+pnpm demo:identity-a2a
+```
+
+[View the code](./identity-a2a)
+
+### Skyfire KYA demo
+
+A demo showing how Skyfire KYA (Know Your Agent) tokens can work on top of ACK-ID's identity infrastructure.
+
+```sh
+pnpm demo:skyfire-kya
+```
+
+[View the code](./skyfire-kya)
+
 ## Note
 
 These demos are designed as interactive walkthroughs of various ACK flows. The source code is designed with this in mind, and may not be suitable for production environments.


### PR DESCRIPTION
## Summary

Two demos exist in the repository but are missing from documentation:

### 1. Skyfire KYA demo missing from `README.md`

The root `README.md` lists 4 demos (identity, identity-a2a, payments, e2e), but `package.json` and `AGENTS.md` both include a 5th: `demo:skyfire-kya`. Added the Skyfire KYA demo section to the root README.

### 2. Identity A2A and Skyfire KYA demos missing from `demos/README.md`

The `demos/README.md` only lists 3 demos (identity, payments, e2e), missing both `identity-a2a` and `skyfire-kya`. Added both.

### Files Changed

- `README.md` — Added Skyfire KYA demo section after End-to-End Demo
- `demos/README.md` — Added Identity A2A and Skyfire KYA demo sections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation with comprehensive demo guides
  * Added Skyfire KYA demo documentation with execution commands and source links
  * Added Identity A2A demo documentation with setup instructions and references
  * Expanded README with clear navigation to demo implementations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentcommercekit/ack/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->