### PR TITLE
docs: fix missing Zod v4 import examples in package READMEs

### DIFF
--- a/packages/ack-id/README.md
+++ b/packages/ack-id/README.md
@@ -88,12 +88,11 @@ isControllerClaim(credential.credentialSubject)
 
 ```ts
 // Zod v4 schema
-
-// Valibot schema
-import { controllerClaimSchema } from "@agentcommercekit/ack-id/schemas/valibot"
+import { controllerClaimSchema } from "@agentcommercekit/ack-id/schemas/zod/v4"
 // Zod v3 schema
 import { controllerClaimSchema } from "@agentcommercekit/ack-id/schemas/zod/v3"
-import { controllerClaimSchema } from "@agentcommercekit/ack-id/schemas/zod/v4"
+// Valibot schema
+import { controllerClaimSchema } from "@agentcommercekit/ack-id/schemas/valibot"
 ```
 
 ## A2A Support

--- a/packages/ack-pay/README.md
+++ b/packages/ack-pay/README.md
@@ -118,12 +118,11 @@ isPaymentReceiptClaim(credential.credentialSubject)
 
 ```ts
 // Zod v4 schema
-
-// Valibot schema
-import { paymentRequestSchema } from "@agentcommercekit/ack-pay/schemas/valibot"
+import { paymentRequestSchema } from "@agentcommercekit/ack-pay/schemas/zod/v4"
 // Zod v3 schema
 import { paymentRequestSchema } from "@agentcommercekit/ack-pay/schemas/zod/v3"
-import { paymentRequestSchema } from "@agentcommercekit/ack-pay/schemas/zod/v4"
+// Valibot schema
+import { paymentRequestSchema } from "@agentcommercekit/ack-pay/schemas/valibot"
 ```
 
 ## Agent Commerce Kit Version

--- a/packages/caip/README.md
+++ b/packages/caip/README.md
@@ -132,21 +132,20 @@ const nftToken: Caip19AssetId =
 
 ```ts
 // Zod v4 schemas
-
-// Valibot schemas
 import {
   caip2ChainIdSchema,
   caip10AccountIdSchema,
-} from "@agentcommercekit/caip/schemas/valibot"
+} from "@agentcommercekit/caip/schemas/zod/v4"
 // Zod v3 schemas
 import {
   caip2ChainIdSchema,
   caip10AccountIdSchema,
 } from "@agentcommercekit/caip/schemas/zod/v3"
+// Valibot schemas
 import {
   caip2ChainIdSchema,
   caip10AccountIdSchema,
-} from "@agentcommercekit/caip/schemas/zod/v4"
+} from "@agentcommercekit/caip/schemas/valibot"
 ```
 
 ## Resources

--- a/packages/did/README.md
+++ b/packages/did/README.md
@@ -127,12 +127,11 @@ const { did, didDocument } = createDidWebDocumentFromKeypair({
 
 ```ts
 // Zod v4 schemas
-
-// Valibot schemas
-import { didUriSchema } from "@agentcommercekit/did/schemas/valibot"
+import { didUriSchema } from "@agentcommercekit/did/schemas/zod/v4"
 // Zod v3 schemas
 import { didUriSchema } from "@agentcommercekit/did/schemas/zod/v3"
-import { didUriSchema } from "@agentcommercekit/did/schemas/zod/v4"
+// Valibot schemas
+import { didUriSchema } from "@agentcommercekit/did/schemas/valibot"
 ```
 
 ## License (MIT)

--- a/packages/jwt/README.md
+++ b/packages/jwt/README.md
@@ -54,12 +54,11 @@ The package provides schemas for validating JWT strings with Zod and Valibot:
 
 ```ts
 // Zod v4
-
-// Valibot
-import { jwtStringSchema } from "@agentcommercekit/jwt/schemas/valibot"
+import { jwtStringSchema } from "@agentcommercekit/jwt/schemas/zod/v4"
 // Zod v3
 import { jwtStringSchema } from "@agentcommercekit/jwt/schemas/zod/v3"
-import { jwtStringSchema } from "@agentcommercekit/jwt/schemas/zod/v4"
+// Valibot
+import { jwtStringSchema } from "@agentcommercekit/jwt/schemas/valibot"
 ```
 
 ## API

--- a/packages/vc/README.md
+++ b/packages/vc/README.md
@@ -108,12 +108,11 @@ const revoked = await isRevoked(credential)
 
 ```ts
 // Zod v4 schemas
-
-// Valibot schemas
-import { credentialSchema } from "@agentcommercekit/vc/schemas/valibot"
+import { credentialSchema } from "@agentcommercekit/vc/schemas/zod/v4"
 // Zod v3 schemas
 import { credentialSchema } from "@agentcommercekit/vc/schemas/zod/v3"
-import { credentialSchema } from "@agentcommercekit/vc/schemas/zod/v4"
+// Valibot schemas
+import { credentialSchema } from "@agentcommercekit/vc/schemas/valibot"
 ```
 
 ## License (MIT)


### PR DESCRIPTION
## Summary

Across 6 package READMEs, the Schema Validation code examples have the Zod v4 import missing. The `// Zod v4` comment exists but is followed by an empty line, then the Valibot import — making it appear that Zod v4 has no import path. The actual Zod v4 import is misplaced at the bottom, detached from its comment.

### Before (all 6 packages)

```ts
// Zod v4 schemas
                          <-- empty line, no import
// Valibot schemas
import { ... } from ".../schemas/valibot"
// Zod v3 schemas
import { ... } from ".../schemas/zod/v3"
import { ... } from ".../schemas/zod/v4"   <-- orphaned at bottom
```

### After

```ts
// Zod v4 schemas
import { ... } from ".../schemas/zod/v4"   <-- now under its comment
// Zod v3 schemas
import { ... } from ".../schemas/zod/v3"
// Valibot schemas
import { ... } from ".../schemas/valibot"
```

### Affected packages

- `@agentcommercekit/caip`
- `@agentcommercekit/did`
- `@agentcommercekit/jwt`
- `@agentcommercekit/vc`
- `@agentcommercekit/ack-id`
- `@agentcommercekit/ack-pay`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized schema validation code examples across package documentation to present library imports (Zod v4, Zod v3, and Valibot) in a consistent order, improving documentation clarity and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentcommercekit/ack/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->