### PR TITLE
fix(ack-pay): format errors.ts to satisfy oxfmt check

### DIFF
--- a/packages/ack-pay/src/errors.ts
+++ b/packages/ack-pay/src/errors.ts
@@ -1,5 +1,8 @@
 export class InvalidPaymentRequestTokenError extends Error {
-  constructor(message = "Invalid payment request token", options?: ErrorOptions) {
+  constructor(
+    message = "Invalid payment request token",
+    options?: ErrorOptions,
+  ) {
     super(message, options)
     this.name = "InvalidPaymentRequestTokenError"
   }


### PR DESCRIPTION
## Why

CI on `main` is red. The `check:format` step (`oxfmt --check .`) fails on `packages/ack-pay/src/errors.ts`:

```
packages/ack-pay/src/errors.ts (0ms)
Format issues found in above 1 files.
##[error]//#check:format: ... pnpm run check:format exited (1)
```

This was introduced in bdf929d (`fix(ack-pay): preserve original error cause in verifyPaymentRequestToken`), which added the `options?: ErrorOptions` parameter and pushed the constructor signature past oxfmt's print width without reformatting.

## What

Run `oxfmt` on the file, wrapping the constructor parameters across multiple lines. No behavioral change.

`pnpm run check:format` now passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted internal code structure for improved maintainability and readability.

**Note:** This release contains no user-facing changes or functional improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->