### PR TITLE
fix(vc): bind credential verification to the signed proof (#105, #108)

### DIFF
--- a/.changeset/bind-parsed-credential-to-proof.md
+++ b/.changeset/bind-parsed-credential-to-proof.md
@@ -1,5 +1,8 @@
 ---
 "@agentcommercekit/vc": patch
+"@agentcommercekit/ack-pay": patch
 ---
 
 Bind credential verification to the signed proof. `verifyProof()` now returns the credential decoded from `proof.jwt`, and `verifyParsedCredential()` runs every downstream check (expiry, revocation, trusted issuer, and claim verifiers) against that verified credential rather than the caller-supplied object. It also now returns the verified credential, so consumers can read signed fields from the return value instead of the object they passed in. On the parsed-credential input path a caller could previously attach a valid `proof.jwt` while mutating the outer `credentialSubject`, `issuer`, etc.; those fields were trusted directly. Now they are ignored in favor of the signed payload. Fixes #105 and #108.
+
+`verifyPaymentReceipt()` now reads the receipt returned by `verifyParsedCredential()` before using signed receipt fields, so parsed receipt callers cannot swap the outer `paymentRequestToken` away from the token in `proof.jwt`.

--- a/.changeset/bind-parsed-credential-to-proof.md
+++ b/.changeset/bind-parsed-credential-to-proof.md
@@ -1,0 +1,5 @@
+---
+"@agentcommercekit/vc": patch
+---
+
+Bind credential verification to the signed proof. `verifyProof()` now returns the credential decoded from `proof.jwt`, and `verifyParsedCredential()` runs every downstream check (expiry, revocation, trusted issuer, and claim verifiers) against that verified credential rather than the caller-supplied object. It also now returns the verified credential, so consumers can read signed fields from the return value instead of the object they passed in. On the parsed-credential input path a caller could previously attach a valid `proof.jwt` while mutating the outer `credentialSubject`, `issuer`, etc.; those fields were trusted directly. Now they are ignored in favor of the signed payload. Fixes #105 and #108.

--- a/demos/e2e/src/credential-verifier.ts
+++ b/demos/e2e/src/credential-verifier.ts
@@ -80,12 +80,16 @@ export class CredentialVerifier {
       throw new InvalidCredentialSubjectError()
     }
 
-    await verifyParsedCredential(parsedCredential, {
+    const verifiedCredential = await verifyParsedCredential(parsedCredential, {
       resolver: this.resolver,
       trustedIssuers: this.trustedIssuers,
       verifiers: [getControllerClaimVerifier()],
     })
 
-    return parsedCredential
+    if (!isControllerCredential(verifiedCredential)) {
+      throw new InvalidCredentialSubjectError()
+    }
+
+    return verifiedCredential as Verifiable<ControllerCredential>
   }
 }

--- a/examples/verifier/src/routes/verify.ts
+++ b/examples/verifier/src/routes/verify.ts
@@ -41,7 +41,7 @@ app.post(
       credential = await parseJwtCredential(credential, resolver)
     }
 
-    await verifyParsedCredential(credential, {
+    credential = await verifyParsedCredential(credential, {
       trustedIssuers,
       resolver,
       verifiers: [getControllerClaimVerifier(), getReceiptClaimVerifier()],

--- a/packages/ack-pay/src/verify-payment-receipt.test.ts
+++ b/packages/ack-pay/src/verify-payment-receipt.test.ts
@@ -102,6 +102,49 @@ describe("verifyPaymentReceipt()", () => {
     expect(result.paymentRequest).toBeDefined()
   })
 
+  it("uses the signed paymentRequestToken for parsed credentials", async () => {
+    const spoofedReceipt = {
+      ...signedReceipt,
+      credentialSubject: {
+        ...signedReceipt.credentialSubject,
+        paymentRequestToken: signedReceiptJwt,
+      },
+    }
+
+    const result = await verifyPaymentReceipt(spoofedReceipt, {
+      resolver,
+    })
+
+    expect(result.receipt).not.toBe(spoofedReceipt)
+    expect(result.receipt.credentialSubject.paymentRequestToken).toBe(
+      paymentRequestToken,
+    )
+    expect(result.paymentRequestToken).toBe(paymentRequestToken)
+    expect(result.paymentRequest).toBeDefined()
+  })
+
+  it("returns the signed paymentRequestToken when token verification is disabled", async () => {
+    const spoofedReceipt = {
+      ...signedReceipt,
+      credentialSubject: {
+        ...signedReceipt.credentialSubject,
+        paymentRequestToken: signedReceiptJwt,
+      },
+    }
+
+    const result = await verifyPaymentReceipt(spoofedReceipt, {
+      resolver,
+      verifyPaymentRequestTokenJwt: false,
+    })
+
+    expect(result.receipt).not.toBe(spoofedReceipt)
+    expect(result.receipt.credentialSubject.paymentRequestToken).toBe(
+      paymentRequestToken,
+    )
+    expect(result.paymentRequestToken).toBe(paymentRequestToken)
+    expect(result.paymentRequest).toBeNull()
+  })
+
   it("preserves receipt metadata through JWT verification", async () => {
     const evidenceMetadata = {
       policyRef: "policy://merchant-spend-v3",

--- a/packages/ack-pay/src/verify-payment-receipt.ts
+++ b/packages/ack-pay/src/verify-payment-receipt.ts
@@ -9,12 +9,15 @@ import {
   type Verifiable,
   type W3CCredential,
 } from "@agentcommercekit/vc"
+import * as v from "valibot"
 
 import type { PaymentRequest } from "./payment-request"
 import {
   getReceiptClaimVerifier,
   isPaymentReceiptCredential,
+  type PaymentReceiptCredential,
 } from "./receipt-claim-verifier"
+import { paymentReceiptClaimSchema } from "./schemas/valibot"
 import { verifyPaymentRequestToken } from "./verify-payment-request-token"
 
 interface VerifyPaymentReceiptOptions {
@@ -34,6 +37,12 @@ interface VerifyPaymentReceiptOptions {
    * The issuer of the paymentRequestToken
    */
   paymentRequestIssuer?: string
+}
+
+function isVerifiedPaymentReceiptCredential(
+  credential: Verifiable<W3CCredential>,
+): credential is Verifiable<PaymentReceiptCredential> {
+  return v.is(paymentReceiptClaimSchema, credential.credentialSubject)
 }
 
 /**
@@ -79,19 +88,25 @@ export async function verifyPaymentReceipt(
     )
   }
 
-  await verifyParsedCredential(parsedCredential, {
+  const verifiedReceipt = await verifyParsedCredential(parsedCredential, {
     resolver,
     trustedIssuers: trustedReceiptIssuers,
     verifiers: [getReceiptClaimVerifier()],
   })
 
+  if (!isVerifiedPaymentReceiptCredential(verifiedReceipt)) {
+    throw new InvalidCredentialError(
+      "Credential is not a PaymentReceiptCredential",
+    )
+  }
+
   // Verify the paymentRequestToken is a valid JWT
   const paymentRequestToken =
-    parsedCredential.credentialSubject.paymentRequestToken
+    verifiedReceipt.credentialSubject.paymentRequestToken
 
   if (!verifyPaymentRequestTokenJwt) {
     return {
-      receipt: parsedCredential,
+      receipt: verifiedReceipt,
       paymentRequestToken,
       paymentRequest: null,
     }
@@ -117,7 +132,7 @@ export async function verifyPaymentReceipt(
   )
 
   return {
-    receipt: parsedCredential,
+    receipt: verifiedReceipt,
     paymentRequestToken,
     paymentRequest,
   }

--- a/packages/vc/src/verification/verify-parsed-credential.test.ts
+++ b/packages/vc/src/verification/verify-parsed-credential.test.ts
@@ -1,12 +1,10 @@
-import {
-  createDidDocumentFromKeypair,
-  createDidWebUri,
-  getDidResolver,
-} from "@agentcommercekit/did"
+import { createDidKeyUri, getDidResolver } from "@agentcommercekit/did"
+import { createJwtSigner } from "@agentcommercekit/jwt"
 import { generateKeypair } from "@agentcommercekit/keys"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { createCredential } from "../create-credential"
+import { signCredential } from "../signing/sign-credential"
 import type { Verifiable, W3CCredential } from "../types"
 import {
   CredentialExpiredError,
@@ -17,9 +15,11 @@ import {
 } from "./errors"
 import { isExpired } from "./is-expired"
 import { isRevoked } from "./is-revoked"
+import { parseJwtCredential } from "./parse-jwt-credential"
 import { verifyParsedCredential } from "./verify-parsed-credential"
-import { verifyProof } from "./verify-proof"
 
+// Expiry and revocation are checked elsewhere; mock them so each test can
+// drive those branches independently of the (real) signed credential.
 vi.mock("./is-expired", () => ({
   isExpired: vi.fn(),
 }))
@@ -28,26 +28,14 @@ vi.mock("./is-revoked", () => ({
   isRevoked: vi.fn(),
 }))
 
-vi.mock("./verify-proof", () => ({
-  verifyProof: vi.fn(),
-}))
-
 async function setup() {
   const resolver = getDidResolver()
-  const subjectDid = createDidWebUri("https://subject.example.com")
 
   const issuerKeypair = await generateKeypair("secp256k1")
-  const issuerDid = createDidWebUri("https://issuer.example.com")
-  resolver.addToCache(
-    issuerDid,
-    createDidDocumentFromKeypair({
-      did: issuerDid,
-      keypair: issuerKeypair,
-    }),
-  )
+  const issuerDid = createDidKeyUri(issuerKeypair)
+  const subjectDid = createDidKeyUri(await generateKeypair("secp256k1"))
 
-  // Generate an unsigned attestation
-  const credential = createCredential({
+  const unsigned = createCredential({
     id: "test-credential",
     type: "TestCredential",
     subject: subjectDid,
@@ -57,18 +45,13 @@ async function setup() {
     },
   })
 
-  credential.issuer = {
-    id: issuerDid,
-  }
+  const jwt = await signCredential(unsigned, {
+    did: issuerDid,
+    signer: createJwtSigner(issuerKeypair),
+  })
 
-  const vc = {
-    ...credential,
-    // just dummy fields, we mock the actual proof verification
-    proof: {
-      type: "JwtProof2020",
-      jwt: "test.jwt.token",
-    },
-  } as unknown as Verifiable<W3CCredential>
+  // A real parsed credential, with a signed `proof.jwt`.
+  const vc = await parseJwtCredential(jwt, resolver)
 
   return { vc, issuerDid, resolver }
 }
@@ -77,7 +60,6 @@ describe("verifyParsedCredential", () => {
   beforeEach(() => {
     vi.mocked(isExpired).mockReturnValue(false)
     vi.mocked(isRevoked).mockResolvedValue(false)
-    vi.mocked(verifyProof).mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -85,15 +67,29 @@ describe("verifyParsedCredential", () => {
   })
 
   it("throws when no proof is present", async () => {
-    const { vc: baseVc, issuerDid, resolver } = await setup()
-
-    const vc = {
-      ...baseVc,
-      proof: undefined,
-    }
+    const { vc, issuerDid, resolver } = await setup()
 
     await expect(
-      verifyParsedCredential(vc, {
+      verifyParsedCredential(
+        { ...vc, proof: undefined } as unknown as W3CCredential,
+        {
+          trustedIssuers: [issuerDid],
+          resolver,
+        },
+      ),
+    ).rejects.toThrow(InvalidProofError)
+  })
+
+  it("throws for an invalid proof", async () => {
+    const { vc, issuerDid, resolver } = await setup()
+
+    const tampered = {
+      ...vc,
+      proof: { type: "JwtProof2020", jwt: "invalid.jwt.token" },
+    } as unknown as Verifiable<W3CCredential>
+
+    await expect(
+      verifyParsedCredential(tampered, {
         trustedIssuers: [issuerDid],
         resolver,
       }),
@@ -135,19 +131,6 @@ describe("verifyParsedCredential", () => {
         resolver,
       }),
     ).rejects.toThrow(UntrustedIssuerError)
-  })
-
-  it("throws for an invalid proof", async () => {
-    const { vc, issuerDid, resolver } = await setup()
-
-    vi.mocked(verifyProof).mockRejectedValueOnce(new InvalidProofError())
-
-    await expect(
-      verifyParsedCredential(vc, {
-        trustedIssuers: [issuerDid],
-        resolver,
-      }),
-    ).rejects.toThrow(InvalidProofError)
   })
 
   it("throws if any claim verifier fails", async () => {
@@ -231,5 +214,109 @@ describe("verifyParsedCredential", () => {
         ],
       }),
     ).resolves.not.toThrow()
+  })
+
+  // Regression for #105 / #108: on the parsed-credential input path, the
+  // top-level fields are caller-supplied and not bound to the signed proof.
+  // Verification must read the signed payload (`proof.jwt`), so mutating the
+  // outer object cannot bypass the issuer or claim-verifier checks.
+  describe("binds checks to the signed proof, not caller-supplied fields", () => {
+    it("rejects a spoofed issuer even when the outer object names a trusted DID", async () => {
+      const { vc, resolver } = await setup()
+
+      const spoofedTrustedDid = "did:web:trusted.example.com"
+      const spoofed = {
+        ...vc,
+        issuer: { id: spoofedTrustedDid },
+      } as Verifiable<W3CCredential>
+
+      // The outer issuer claims the trusted DID, but the signed payload was
+      // issued by the real (untrusted-here) issuer, so this must be rejected.
+      await expect(
+        verifyParsedCredential(spoofed, {
+          trustedIssuers: [spoofedTrustedDid],
+          resolver,
+        }),
+      ).rejects.toThrow(UntrustedIssuerError)
+    })
+
+    it("runs claim verifiers against the signed subject, not a mutated outer subject", async () => {
+      const { vc, issuerDid, resolver } = await setup()
+
+      const spoofed = {
+        ...vc,
+        credentialSubject: { ...vc.credentialSubject, test: "spoofed" },
+      } as Verifiable<W3CCredential>
+
+      // The verifier accepts only the signed value ("test"). If verification
+      // read the mutated outer subject ("spoofed") this would reject; binding
+      // to the signed payload means it sees "test" and passes.
+      await expect(
+        verifyParsedCredential(spoofed, {
+          trustedIssuers: [issuerDid],
+          resolver,
+          verifiers: [
+            {
+              accepts: () => true,
+              verify: (subject) =>
+                (subject as { test?: string }).test === "test"
+                  ? Promise.resolve()
+                  : Promise.reject(
+                      new Error("subject was not the signed value"),
+                    ),
+            },
+          ],
+        }),
+      ).resolves.not.toThrow()
+    })
+
+    it("returns the credential decoded from the signed proof, not the caller-supplied object", async () => {
+      const { vc, issuerDid, resolver } = await setup()
+
+      const spoofed = {
+        ...vc,
+        issuer: { id: "did:web:attacker.example.com" },
+        credentialSubject: { ...vc.credentialSubject, test: "spoofed" },
+      } as Verifiable<W3CCredential>
+
+      const verified = await verifyParsedCredential(spoofed, { resolver })
+
+      // The returned credential is the signed one, regardless of the mutated
+      // outer fields the caller supplied.
+      expect(verified.issuer.id).toBe(issuerDid)
+      expect((verified.credentialSubject as { test?: string }).test).toBe(
+        "test",
+      )
+    })
+
+    it("selects claim verifiers by the signed type, not a mutated outer type", async () => {
+      const { vc, issuerDid, resolver } = await setup()
+
+      const spoofed = {
+        ...vc,
+        type: ["VerifiableCredential", "SpoofedType"],
+      } as Verifiable<W3CCredential>
+
+      let receivedTypes: string[] | undefined
+
+      await expect(
+        verifyParsedCredential(spoofed, {
+          trustedIssuers: [issuerDid],
+          resolver,
+          verifiers: [
+            {
+              accepts: (type) => {
+                receivedTypes = type
+                return type.includes("TestCredential")
+              },
+              verify: () => Promise.resolve(),
+            },
+          ],
+        }),
+      ).resolves.toBeDefined()
+
+      expect(receivedTypes).toContain("TestCredential")
+      expect(receivedTypes).not.toContain("SpoofedType")
+    })
   })
 })

--- a/packages/vc/src/verification/verify-parsed-credential.ts
+++ b/packages/vc/src/verification/verify-parsed-credential.ts
@@ -48,23 +48,35 @@ function isVerifiable(
  *
  * @param credential - The credential to verify.
  * @param options - The {@link VerifyCredentialOptions} to use
+ * @returns The verified credential decoded from the signed proof. Callers
+ *   should use this returned value rather than the object they passed in, whose
+ *   top-level fields are not bound to the signature.
  * @throws on error
  */
 export async function verifyParsedCredential(
   credential: W3CCredential,
   options: VerifyCredentialOptions,
-): Promise<void> {
+): Promise<Verifiable<W3CCredential>> {
   if (!isVerifiable(credential)) {
     throw new InvalidProofError("Credential does not contain a proof")
   }
 
-  await verifyProof(credential.proof, options.resolver)
+  // verifyProof returns the credential decoded from the signed proof. The
+  // top-level fields of a caller-supplied parsed credential are NOT bound to
+  // that signed payload, so every check below (expiry, revocation, trusted
+  // issuer, claim verifiers) runs against the verified credential rather than
+  // the caller-supplied object, which could otherwise be mutated to diverge
+  // from what was actually signed. (#105, #108)
+  const verifiedCredential = await verifyProof(
+    credential.proof,
+    options.resolver,
+  )
 
-  if (isExpired(credential)) {
+  if (isExpired(verifiedCredential)) {
     throw new CredentialExpiredError()
   }
 
-  if (await isRevoked(credential)) {
+  if (await isRevoked(verifiedCredential)) {
     throw new CredentialRevokedError()
   }
 
@@ -72,27 +84,32 @@ export async function verifyParsedCredential(
   // if the array is empty). If it is not defined, we skip the check.
   if (
     Array.isArray(options.trustedIssuers) &&
-    !options.trustedIssuers.includes(credential.issuer.id)
+    !options.trustedIssuers.includes(verifiedCredential.issuer.id)
   ) {
     throw new UntrustedIssuerError(
-      `Issuer is not trusted '${credential.issuer.id}'`,
+      `Issuer is not trusted '${verifiedCredential.issuer.id}'`,
     )
   }
 
   // If verifiers are provided, we verify the credential against them.
   if (options.verifiers?.length) {
     const verifiers = options.verifiers.filter((v) =>
-      v.accepts(credential.type),
+      v.accepts(verifiedCredential.type),
     )
 
     if (!verifiers.length) {
       throw new UnsupportedCredentialTypeError(
-        `Unsupported credential type: ${credential.type.join(", ")}`,
+        `Unsupported credential type: ${verifiedCredential.type.join(", ")}`,
       )
     }
 
     for (const verifier of verifiers) {
-      await verifier.verify(credential.credentialSubject, options.resolver)
+      await verifier.verify(
+        verifiedCredential.credentialSubject,
+        options.resolver,
+      )
     }
   }
+
+  return verifiedCredential
 }

--- a/packages/vc/src/verification/verify-proof.test.ts
+++ b/packages/vc/src/verification/verify-proof.test.ts
@@ -56,13 +56,22 @@ describe("verifyProof", () => {
     ).rejects.toThrow(InvalidProofError)
   })
 
-  it("successfully verifies a valid JwtProof2020", async () => {
+  it("successfully verifies a valid JwtProof2020 and returns the decoded credential", async () => {
     const validProof = {
       type: "JwtProof2020",
       jwt: "valid.jwt.token",
     }
 
-    vi.mocked(verifyCredential).mockResolvedValueOnce({} as VerifiedCredential)
-    await expect(verifyProof(validProof, mockResolver)).resolves.not.toThrow()
+    const decoded = {
+      issuer: { id: "did:example:signed-issuer" },
+    }
+
+    vi.mocked(verifyCredential).mockResolvedValueOnce({
+      verifiableCredential: decoded,
+    } as unknown as VerifiedCredential)
+
+    // The returned credential must come from the decoded proof payload, not the
+    // caller-supplied proof object.
+    await expect(verifyProof(validProof, mockResolver)).resolves.toBe(decoded)
   })
 })

--- a/packages/vc/src/verification/verify-proof.test.ts
+++ b/packages/vc/src/verification/verify-proof.test.ts
@@ -13,14 +13,39 @@ vi.mock("did-jwt-vc", async () => {
   }
 })
 
-vi.mock("./verify-credential-jwt", () => ({
-  verifyCredentialJwt: vi.fn(),
-}))
+function createVerifiedCredential(
+  verifiableCredential: VerifiedCredential["verifiableCredential"],
+  jwt: string,
+): VerifiedCredential {
+  const issuer = verifiableCredential.issuer.id
+
+  return {
+    verified: true,
+    payload: {},
+    didResolutionResult: {
+      didResolutionMetadata: {},
+      didDocument: null,
+      didDocumentMetadata: {},
+    },
+    issuer,
+    signer: {
+      id: `${issuer}#key-1`,
+      type: "JsonWebKey2020",
+      controller: issuer,
+    },
+    jwt,
+    verifiableCredential,
+  }
+}
 
 describe("verifyProof", () => {
-  const mockResolver = {
-    resolve: vi.fn(),
-  } as unknown as Resolvable
+  const mockResolver: Resolvable = {
+    resolve: vi.fn(async () => ({
+      didResolutionMetadata: {},
+      didDocument: null,
+      didDocumentMetadata: {},
+    })),
+  }
 
   it("throws for invalid proof payload", async () => {
     const invalidProof = {
@@ -44,7 +69,7 @@ describe("verifyProof", () => {
     )
   })
 
-  it("handles verification errors from verifyCredentialJwt", async () => {
+  it("handles verification errors from verifyCredential", async () => {
     const proofWithInvalidJwt = {
       type: "JwtProof2020",
       jwt: "invalid.jwt.token",
@@ -63,15 +88,48 @@ describe("verifyProof", () => {
     }
 
     const decoded = {
+      "@context": ["https://www.w3.org/2018/credentials/v1"],
+      type: ["VerifiableCredential", "TestCredential"],
       issuer: { id: "did:example:signed-issuer" },
+      issuanceDate: "2026-01-01T00:00:00.000Z",
+      credentialSubject: { id: "did:example:subject" },
+      proof: validProof,
     }
 
-    vi.mocked(verifyCredential).mockResolvedValueOnce({
-      verifiableCredential: decoded,
-    } as unknown as VerifiedCredential)
+    vi.mocked(verifyCredential).mockResolvedValueOnce(
+      createVerifiedCredential(decoded, validProof.jwt),
+    )
 
     // The returned credential must come from the decoded proof payload, not the
     // caller-supplied proof object.
     await expect(verifyProof(validProof, mockResolver)).resolves.toBe(decoded)
+  })
+
+  it("throws when verifyCredential returns a malformed decoded credential", async () => {
+    const validProof = {
+      type: "JwtProof2020",
+      jwt: "valid.jwt.token",
+    }
+    const validDecoded = {
+      "@context": ["https://www.w3.org/2018/credentials/v1"],
+      type: ["VerifiableCredential", "TestCredential"],
+      issuer: { id: "did:example:signed-issuer" },
+      issuanceDate: "2026-01-01T00:00:00.000Z",
+      credentialSubject: { id: "did:example:subject" },
+      proof: validProof,
+    }
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- exercises malformed data from the external verifier.
+    const malformedCredential = {
+      issuer: { id: "did:example:signed-issuer" },
+    } as unknown as VerifiedCredential["verifiableCredential"]
+
+    vi.mocked(verifyCredential).mockResolvedValueOnce({
+      ...createVerifiedCredential(validDecoded, validProof.jwt),
+      verifiableCredential: malformedCredential,
+    })
+
+    await expect(verifyProof(validProof, mockResolver)).rejects.toThrow(
+      InvalidProofError,
+    )
   })
 })

--- a/packages/vc/src/verification/verify-proof.ts
+++ b/packages/vc/src/verification/verify-proof.ts
@@ -26,16 +26,24 @@ export function isJwtProof(proof: unknown): proof is JwtProof {
   )
 }
 
+/**
+ * Verify a JWT proof and return the credential decoded from the signed payload.
+ *
+ * The returned credential is reconstructed from `proof.jwt`, so its fields are
+ * exactly what was signed, rather than whatever a caller may have placed on the
+ * surrounding object.
+ */
 async function verifyJwtProof(
   proof: Verifiable<W3CCredential>["proof"],
   resolver: Resolvable,
-): Promise<void> {
+): Promise<Verifiable<W3CCredential>> {
   if (!isJwtProof(proof)) {
     throw new InvalidProofError()
   }
 
   try {
-    await verifyCredential(proof.jwt, resolver)
+    const { verifiableCredential } = await verifyCredential(proof.jwt, resolver)
+    return verifiableCredential as Verifiable<W3CCredential>
   } catch (_error) {
     throw new InvalidProofError()
   }
@@ -46,11 +54,14 @@ async function verifyJwtProof(
  *
  * @param proof - The credential proof to verify
  * @param resolver - The resolver to use for did resolution
+ * @returns The credential decoded from the signed proof. For JWT proofs this is
+ *   the payload recovered from `proof.jwt`, so callers can rely on it instead of
+ *   on caller-supplied top-level fields that are not bound to the signature.
  */
 export async function verifyProof(
   proof: Verifiable<W3CCredential>["proof"],
   resolver: Resolvable,
-): Promise<void> {
+): Promise<Verifiable<W3CCredential>> {
   switch (proof.type) {
     case "JwtProof2020":
       return verifyJwtProof(proof, resolver)

--- a/packages/vc/src/verification/verify-proof.ts
+++ b/packages/vc/src/verification/verify-proof.ts
@@ -9,6 +9,39 @@ interface JwtProof {
   jwt: string
 }
 
+type UnknownRecord = Record<string, unknown>
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string")
+}
+
+function isVerifiableCredential(
+  value: unknown,
+): value is Verifiable<W3CCredential> {
+  if (!isRecord(value)) {
+    return false
+  }
+
+  const issuer = value.issuer
+  const credentialSubject = value.credentialSubject
+  const proof = value.proof
+
+  return (
+    isStringArray(value["@context"]) &&
+    isStringArray(value.type) &&
+    typeof value.issuanceDate === "string" &&
+    isRecord(issuer) &&
+    typeof issuer.id === "string" &&
+    isRecord(credentialSubject) &&
+    isRecord(proof) &&
+    typeof proof.type === "string"
+  )
+}
+
 /**
  * Check if a proof is a JWT proof
  *
@@ -43,8 +76,16 @@ async function verifyJwtProof(
 
   try {
     const { verifiableCredential } = await verifyCredential(proof.jwt, resolver)
-    return verifiableCredential as Verifiable<W3CCredential>
+    if (!isVerifiableCredential(verifiableCredential)) {
+      throw new InvalidProofError("Verified credential has invalid shape")
+    }
+
+    return verifiableCredential
   } catch (_error) {
+    if (_error instanceof InvalidProofError) {
+      throw _error
+    }
+
     throw new InvalidProofError()
   }
 }


### PR DESCRIPTION
## TL;DR

On the parsed-credential input path, `verifyParsedCredential()` verified `proof.jwt` but then ran expiry, revocation, `trustedIssuers`, and claim-verifier checks against the **caller-supplied** outer object. A caller could present a validly-signed `proof.jwt` while mutating the outer `credentialSubject` / `issuer` / `type`, and those mutated fields were trusted. This binds all verification to the signed payload. Fixes #105 and #108.

## What changed (`@agentcommercekit/vc`)

- `verifyProof()` now **returns the credential decoded from `proof.jwt`** (previously `void`).
- `verifyParsedCredential()` runs every downstream check against that verified credential, and **returns it**, so consumers can read signed fields from the return value instead of the object they passed in.

## Where to look

- `packages/vc/src/verification/verify-proof.ts` — `verifyJwtProof` returns the decoded credential.
- `packages/vc/src/verification/verify-parsed-credential.ts` — expiry / revocation / trusted-issuer / claim-verifier checks and the return value now use the verified credential.

## Risk / compatibility

- The return types of `verifyProof` and `verifyParsedCredential` change from `void` to the verified credential. This is backward-compatible: callers that ignore the return value are unaffected. Patch changeset included.
- The behavior change is intentional and scoped to the parsed-credential path: mutated outer fields no longer affect verification.

## Tests

- Rewrote `verify-parsed-credential.test.ts` onto real signed credentials (no mocked proof).
- Regression tests: a spoofed outer `issuer` (pointed at a trusted DID) is rejected; claim verifiers receive the signed subject rather than a mutated one; claim-verifier selection uses the signed `type`; and the returned credential is the signed one.
- `verify-proof.test.ts` asserts the decoded credential is returned.
- `@agentcommercekit/vc`: 51 tests passing. Repo-wide: `check:types`, `test`, `lint` (0 errors), and `oxfmt --check` all pass.

## Relationship to #88

#88 hardens the ACK-Pay receipt path specifically and adds the `paymentOptionId` ↔ Payment Request binding, which lives at the ACK-Pay layer and is not covered here. This PR is the general fix at the `@agentcommercekit/vc` layer and is complementary. With `verifyParsedCredential` now returning the canonical credential, the receipt path's local re-parse in #88 can later be simplified to consume the return value.

---

_Reviewed with ChatGPT 5.5 (xhigh reasoning) in addition to the author. Areas that may still warrant human review: (1) **consumer adoption** — `verifyParsedCredential` now returns the canonical credential, and call sites that read fields after verification should switch to the return value (the receipt path is separately hardened in #88); (2) **expiry / revocation binding** is covered structurally because those checks now receive the verified credential, but the unit tests mock `isExpired` / `isRevoked`, so a maintainer may want an end-to-end test with a genuinely expired or revoked signed credential._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Credential and proof verification is now bound to the signed proof payload, so spoofed or mutated outer fields are ignored.
  * `verifyProof` and `verifyParsedCredential` now return the verified/decoded credential for safer downstream handling.
  * Payment receipt verification now uses the verified receipt to prevent mismatched `paymentRequestToken` values.
* **Tests**
  * Strengthened verification test coverage with real signed JWT credentials and regression cases for spoofed issuer and altered claim fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->