### PR TITLE
fix(vc,ack-pay): bind credential verification to the verified proof (credential forgery)

### DIFF
--- a/.changeset/vc-ackpay-proof-binding.md
+++ b/.changeset/vc-ackpay-proof-binding.md
@@ -1,0 +1,18 @@
+---
+"@agentcommercekit/vc": patch
+"@agentcommercekit/ack-pay": patch
+---
+
+Security: bind credential trust decisions to the verified proof.
+
+`verifyParsedCredential` previously verified the JWT in `proof.jwt` but then made
+every trust decision (expiry, revocation, trusted-issuer, claim verifiers) from
+the caller-supplied credential object, which is not bound to the proof. An
+attacker could wrap a valid `proof.jwt` in an object with tampered `issuer` /
+`credentialSubject` fields and pass verification. `verifyPaymentReceipt` had the
+same gap on its object-input path, returning the tampered `paymentRequestToken`
+and `receipt`.
+
+`verifyProof` and `verifyParsedCredential` now return the credential decoded from
+the verified proof, and all trust decisions and returned values flow from that
+credential. The JWT-string input paths were already safe.

--- a/packages/ack-pay/src/verify-payment-receipt.test.ts
+++ b/packages/ack-pay/src/verify-payment-receipt.test.ts
@@ -102,7 +102,7 @@ describe("verifyPaymentReceipt()", () => {
     expect(result.paymentRequest).toBeDefined()
   })
 
-  it("ignores tampered outer fields on the object path and returns verified values", async () => {
+  it("returns verified values when outer object fields are tampered", async () => {
     // Reuse the valid proof from a legitimately signed receipt, but tamper the
     // outer object's credentialSubject. The forgery must be ignored: all
     // returned values must come from the credential decoded from the proof.

--- a/packages/ack-pay/src/verify-payment-receipt.test.ts
+++ b/packages/ack-pay/src/verify-payment-receipt.test.ts
@@ -102,6 +102,31 @@ describe("verifyPaymentReceipt()", () => {
     expect(result.paymentRequest).toBeDefined()
   })
 
+  it("ignores tampered outer fields on the object path and returns verified values", async () => {
+    // Reuse the valid proof from a legitimately signed receipt, but tamper the
+    // outer object's credentialSubject. The forgery must be ignored: all
+    // returned values must come from the credential decoded from the proof.
+    const tampered = {
+      ...signedReceipt,
+      credentialSubject: {
+        ...signedReceipt.credentialSubject,
+        paymentRequestToken: "forged.jwt.token",
+      },
+    } as Verifiable<W3CCredential>
+
+    const result = await verifyPaymentReceipt(tampered, {
+      resolver,
+      trustedReceiptIssuers: [receiptIssuerDid],
+      verifyPaymentRequestTokenJwt: false,
+    })
+
+    expect(result.paymentRequestToken).toBe(paymentRequestToken)
+    expect(
+      (result.receipt.credentialSubject as { paymentRequestToken: string })
+        .paymentRequestToken,
+    ).toBe(paymentRequestToken)
+  })
+
   it("preserves receipt metadata through JWT verification", async () => {
     const evidenceMetadata = {
       policyRef: "policy://merchant-spend-v3",

--- a/packages/ack-pay/src/verify-payment-receipt.ts
+++ b/packages/ack-pay/src/verify-payment-receipt.ts
@@ -79,19 +79,29 @@ export async function verifyPaymentReceipt(
     )
   }
 
-  await verifyParsedCredential(parsedCredential, {
+  // `verifyParsedCredential` returns the credential decoded from the verified
+  // proof. All reads below use that verified credential, never the
+  // caller-supplied `parsedCredential` object, whose fields are not bound to
+  // the proof and may have been tampered with on the object-input path.
+  const verifiedReceipt = await verifyParsedCredential(parsedCredential, {
     resolver,
     trustedIssuers: trustedReceiptIssuers,
     verifiers: [getReceiptClaimVerifier()],
   })
 
+  if (!isPaymentReceiptCredential(verifiedReceipt)) {
+    throw new InvalidCredentialError(
+      "Verified credential is not a PaymentReceiptCredential",
+    )
+  }
+
   // Verify the paymentRequestToken is a valid JWT
   const paymentRequestToken =
-    parsedCredential.credentialSubject.paymentRequestToken
+    verifiedReceipt.credentialSubject.paymentRequestToken
 
   if (!verifyPaymentRequestTokenJwt) {
     return {
-      receipt: parsedCredential,
+      receipt: verifiedReceipt,
       paymentRequestToken,
       paymentRequest: null,
     }
@@ -117,7 +127,7 @@ export async function verifyPaymentReceipt(
   )
 
   return {
-    receipt: parsedCredential,
+    receipt: verifiedReceipt,
     paymentRequestToken,
     paymentRequest,
   }

--- a/packages/ack-pay/src/verify-payment-receipt.ts
+++ b/packages/ack-pay/src/verify-payment-receipt.ts
@@ -73,6 +73,8 @@ export async function verifyPaymentReceipt(
     throw new InvalidCredentialError("Receipt is not a JWT or Credential")
   }
 
+  // Cheap structural fast-reject only — NOT a trust boundary. The authoritative
+  // receipt check runs on the proof-verified credential below.
   if (!isPaymentReceiptCredential(parsedCredential)) {
     throw new InvalidCredentialError(
       "Credential is not a PaymentReceiptCredential",

--- a/packages/vc/src/verification/verify-parsed-credential.test.ts
+++ b/packages/vc/src/verification/verify-parsed-credential.test.ts
@@ -243,23 +243,24 @@ describe("verifyParsedCredential", () => {
 
     const received: unknown[] = []
 
-    await expect(
-      verifyParsedCredential(tampered, {
-        // Only the real issuer is trusted; the tampered "attacker" issuer is not
-        trustedIssuers: [issuerDid],
-        resolver,
-        verifiers: [
-          {
-            accepts: () => true,
-            verify: (subject) => {
-              received.push(subject)
-              return Promise.resolve()
-            },
+    const result = await verifyParsedCredential(tampered, {
+      // Only the real issuer is trusted; the tampered "attacker" issuer is not
+      trustedIssuers: [issuerDid],
+      resolver,
+      verifiers: [
+        {
+          accepts: () => true,
+          verify: (subject) => {
+            received.push(subject)
+            return Promise.resolve()
           },
-        ],
-      }),
-    ).resolves.not.toThrow()
+        },
+      ],
+    })
 
+    // Returns the verified credential (the contract callers like
+    // verifyPaymentReceipt rely on), not the caller-supplied object
+    expect(result).toBe(verifiedCredential)
     // Trust decisions used the verified payload, not the tampered outer object
     expect(received).toEqual([verifiedSubject])
   })

--- a/packages/vc/src/verification/verify-parsed-credential.test.ts
+++ b/packages/vc/src/verification/verify-parsed-credential.test.ts
@@ -70,6 +70,11 @@ async function setup() {
     },
   } as unknown as Verifiable<W3CCredential>
 
+  // `verifyProof` returns the credential decoded from the verified proof. In
+  // the happy path that matches the object under test, so default the mock to
+  // return `vc` itself.
+  vi.mocked(verifyProof).mockResolvedValue(vc)
+
   return { vc, issuerDid, resolver }
 }
 
@@ -77,7 +82,6 @@ describe("verifyParsedCredential", () => {
   beforeEach(() => {
     vi.mocked(isExpired).mockReturnValue(false)
     vi.mocked(isRevoked).mockResolvedValue(false)
-    vi.mocked(verifyProof).mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -215,6 +219,49 @@ describe("verifyParsedCredential", () => {
         resolver,
       }),
     ).resolves.not.toThrow()
+  })
+
+  it("uses the credential from the verified proof, not the caller-supplied object", async () => {
+    const { vc, issuerDid, resolver } = await setup()
+
+    // The authoritative credential decoded from the verified proof
+    const verifiedSubject = { id: "did:example:subject", role: "user" }
+    const verifiedCredential = {
+      ...vc,
+      issuer: { id: issuerDid },
+      credentialSubject: verifiedSubject,
+    } as unknown as Verifiable<W3CCredential>
+    vi.mocked(verifyProof).mockResolvedValue(verifiedCredential)
+
+    // The caller-supplied object carries tampered fields (untrusted issuer,
+    // escalated subject) while reusing the same valid proof.
+    const tampered = {
+      ...vc,
+      issuer: { id: "did:example:attacker" },
+      credentialSubject: { id: "did:example:subject", role: "admin" },
+    } as unknown as Verifiable<W3CCredential>
+
+    const received: unknown[] = []
+
+    await expect(
+      verifyParsedCredential(tampered, {
+        // Only the real issuer is trusted; the tampered "attacker" issuer is not
+        trustedIssuers: [issuerDid],
+        resolver,
+        verifiers: [
+          {
+            accepts: () => true,
+            verify: (subject) => {
+              received.push(subject)
+              return Promise.resolve()
+            },
+          },
+        ],
+      }),
+    ).resolves.not.toThrow()
+
+    // Trust decisions used the verified payload, not the tampered outer object
+    expect(received).toEqual([verifiedSubject])
   })
 
   it("verifies a valid credential without a list of trusted issuers", async () => {

--- a/packages/vc/src/verification/verify-parsed-credential.test.ts
+++ b/packages/vc/src/verification/verify-parsed-credential.test.ts
@@ -221,7 +221,7 @@ describe("verifyParsedCredential", () => {
     ).resolves.not.toThrow()
   })
 
-  it("uses the credential from the verified proof, not the caller-supplied object", async () => {
+  it("returns the proof-decoded credential and ignores tampered outer fields", async () => {
     const { vc, issuerDid, resolver } = await setup()
 
     // The authoritative credential decoded from the verified proof

--- a/packages/vc/src/verification/verify-parsed-credential.ts
+++ b/packages/vc/src/verification/verify-parsed-credential.ts
@@ -58,13 +58,20 @@ export async function verifyParsedCredential(
     throw new InvalidProofError("Credential does not contain a proof")
   }
 
-  await verifyProof(credential.proof, options.resolver)
+  // The proof (a JWT) is the only authoritative source. `verifyProof` returns
+  // the credential decoded from the verified proof; all trust decisions below
+  // run against that, never against the caller-supplied `credential` object,
+  // whose fields are not bound to the proof and may have been tampered with.
+  const verifiedCredential = await verifyProof(
+    credential.proof,
+    options.resolver,
+  )
 
-  if (isExpired(credential)) {
+  if (isExpired(verifiedCredential)) {
     throw new CredentialExpiredError()
   }
 
-  if (await isRevoked(credential)) {
+  if (await isRevoked(verifiedCredential)) {
     throw new CredentialRevokedError()
   }
 
@@ -72,27 +79,30 @@ export async function verifyParsedCredential(
   // if the array is empty). If it is not defined, we skip the check.
   if (
     Array.isArray(options.trustedIssuers) &&
-    !options.trustedIssuers.includes(credential.issuer.id)
+    !options.trustedIssuers.includes(verifiedCredential.issuer.id)
   ) {
     throw new UntrustedIssuerError(
-      `Issuer is not trusted '${credential.issuer.id}'`,
+      `Issuer is not trusted '${verifiedCredential.issuer.id}'`,
     )
   }
 
   // If verifiers are provided, we verify the credential against them.
   if (options.verifiers?.length) {
     const verifiers = options.verifiers.filter((v) =>
-      v.accepts(credential.type),
+      v.accepts(verifiedCredential.type),
     )
 
     if (!verifiers.length) {
       throw new UnsupportedCredentialTypeError(
-        `Unsupported credential type: ${credential.type.join(", ")}`,
+        `Unsupported credential type: ${verifiedCredential.type.join(", ")}`,
       )
     }
 
     for (const verifier of verifiers) {
-      await verifier.verify(credential.credentialSubject, options.resolver)
+      await verifier.verify(
+        verifiedCredential.credentialSubject,
+        options.resolver,
+      )
     }
   }
 }

--- a/packages/vc/src/verification/verify-parsed-credential.ts
+++ b/packages/vc/src/verification/verify-parsed-credential.ts
@@ -48,12 +48,15 @@ function isVerifiable(
  *
  * @param credential - The credential to verify.
  * @param options - The {@link VerifyCredentialOptions} to use
+ * @returns The credential decoded from the verified proof. Callers MUST use
+ *   this returned value for any post-verification reads — the `credential`
+ *   argument is caller-supplied and is not bound to the proof.
  * @throws on error
  */
 export async function verifyParsedCredential(
   credential: W3CCredential,
   options: VerifyCredentialOptions,
-): Promise<void> {
+): Promise<Verifiable<W3CCredential>> {
   if (!isVerifiable(credential)) {
     throw new InvalidProofError("Credential does not contain a proof")
   }
@@ -105,4 +108,6 @@ export async function verifyParsedCredential(
       )
     }
   }
+
+  return verifiedCredential
 }

--- a/packages/vc/src/verification/verify-proof.test.ts
+++ b/packages/vc/src/verification/verify-proof.test.ts
@@ -56,13 +56,23 @@ describe("verifyProof", () => {
     ).rejects.toThrow(InvalidProofError)
   })
 
-  it("successfully verifies a valid JwtProof2020", async () => {
+  it("returns the credential decoded from the verified proof", async () => {
     const validProof = {
       type: "JwtProof2020",
       jwt: "valid.jwt.token",
     }
 
-    vi.mocked(verifyCredential).mockResolvedValueOnce({} as VerifiedCredential)
-    await expect(verifyProof(validProof, mockResolver)).resolves.not.toThrow()
+    const verifiableCredential = {
+      issuer: { id: "did:example:issuer" },
+      credentialSubject: { id: "did:example:subject" },
+    }
+
+    vi.mocked(verifyCredential).mockResolvedValueOnce({
+      verifiableCredential,
+    } as unknown as VerifiedCredential)
+
+    await expect(verifyProof(validProof, mockResolver)).resolves.toBe(
+      verifiableCredential,
+    )
   })
 })

--- a/packages/vc/src/verification/verify-proof.ts
+++ b/packages/vc/src/verification/verify-proof.ts
@@ -1,8 +1,8 @@
 import type { Resolvable } from "@agentcommercekit/did"
-import { verifyCredential } from "did-jwt-vc"
 
 import type { Verifiable, W3CCredential } from "../types"
 import { InvalidProofError, UnsupportedProofTypeError } from "./errors"
+import { parseJwtCredential } from "./parse-jwt-credential"
 
 interface JwtProof {
   type: "JwtProof2020"
@@ -29,28 +29,35 @@ export function isJwtProof(proof: unknown): proof is JwtProof {
 async function verifyJwtProof(
   proof: Verifiable<W3CCredential>["proof"],
   resolver: Resolvable,
-): Promise<void> {
+): Promise<Verifiable<W3CCredential>> {
   if (!isJwtProof(proof)) {
     throw new InvalidProofError()
   }
 
   try {
-    await verifyCredential(proof.jwt, resolver)
+    return await parseJwtCredential(proof.jwt, resolver)
   } catch (_error) {
     throw new InvalidProofError()
   }
 }
 
 /**
- * Verify a proof
+ * Verify a proof and return the credential decoded from it.
+ *
+ * The returned credential is derived from the verified proof (the JWT payload),
+ * not from any caller-supplied object. Callers MUST treat the returned value as
+ * the authoritative credential: a `JwtProof2020` proof is only bound to the
+ * claims inside its own JWT, so any outer object wrapping the proof can carry
+ * tampered fields that the proof does not attest to.
  *
  * @param proof - The credential proof to verify
  * @param resolver - The resolver to use for did resolution
+ * @returns The {@link Verifiable<W3CCredential>} decoded from the verified proof
  */
 export async function verifyProof(
   proof: Verifiable<W3CCredential>["proof"],
   resolver: Resolvable,
-): Promise<void> {
+): Promise<Verifiable<W3CCredential>> {
   switch (proof.type) {
     case "JwtProof2020":
       return verifyJwtProof(proof, resolver)


### PR DESCRIPTION
## Summary

Fixes a **credential-forgery vulnerability** in `@agentcommercekit/vc` (and its consumer `@agentcommercekit/ack-pay`).

Fixes #105, #108. Supersedes #110 (same root-cause fix; this version reuses `parseJwtCredential` rather than re-casting in `verify-proof.ts`, and conforms to the assertive test-name convention).

`verifyParsedCredential` verified the JWT in `proof.jwt` but then made **every** trust decision — expiry, revocation, trusted-issuer, and claim verification — from the **caller-supplied credential object**, which is not bound to the proof. An attacker could take any legitimately signed credential, parse it to object form, mutate `issuer` / `credentialSubject` / `expirationDate` on the object while keeping the original valid `proof.jwt`, and pass verification.

This is **remotely reachable**: the verifier example accepts a parsed credential object (`POST /verify`), and `verifyPaymentReceipt` had the same gap on its object-input path — it returned the tampered `paymentRequestToken` and `receipt`.

## Fix

The JWT proof is the only authoritative source.

- `verifyProof` now **returns** the credential decoded from the verified proof (via `parseJwtCredential`, which calls did-jwt-vc's `verifyCredential` — signature verification is unchanged).
- `verifyParsedCredential` runs all trust decisions against that verified credential and returns it.
- `verifyPaymentReceipt` uses the **returned** verified credential for the `paymentRequestToken` read and the returned `receipt`.

The JWT-string input paths were already safe (their object is derived from the verified JWT), so legitimate flows are unchanged. `verifyProof` / `verifyParsedCredential` return types widen from `void` to `Verifiable<W3CCredential>` — backward compatible for existing statement callers.

## Verification

- Real-crypto PoCs (sign → parse → tamper → verify) confirm: legit credentials still verify; tampered objects' forged fields are ignored (both for `verifyParsedCredential` and `verifyPaymentReceipt`'s object path).
- Added adversarial regression tests in both packages; `vc` 48/48 and `ack-pay` 34/34 pass; full `pnpm run check` is green.
- Reviewed via an independent multi-agent panel-review loop to convergence (final round: unanimous no-findings).

## Notes

- Scoped to the published packages; demo/example callers that take `JwtString` inputs are already safe.
- Follow-up: add a runtime shape-guard on the did-jwt-vc result inside `parseJwtCredential` (centralizes the one remaining unchecked cast).
- A separate PR (#114) carries the unrelated dependency upgrades, knip setup, and the auth-bypass hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)