### PR TITLE
build(turbo): gate type-aware lint on package builds

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,8 @@
     "//#check:packages": {},
     "//#format": {},
     "//#lint": {
-      "cache": false
+      "cache": false,
+      "dependsOn": ["agentcommercekit#build"]
     },
     "//#lint:fix": {},
     "build": {


### PR DESCRIPTION
## What

Adds `dependsOn: ["agentcommercekit#build"]` to the root `//#lint` turbo task.

## Why

The root `//#lint` task runs oxlint with type-aware checking (`options.typeAware` + `oxlint-tsgolint`), which reads each package's compiled `dist/` to resolve `@agentcommercekit/*` declarations. It declared **no** build dependency.

Under sequential invocation the normal CI command (`turbo build && turbo check`) is safe — the `&&` is a barrier, so `dist/` is fully present before lint runs. But under parallel/forced execution (`turbo check --force`), the build tasks pulled in via `test → ^build` re-clean and rebuild `dist/` concurrently with lint, so lint can read a half-built `dist/` and emit spurious errors:

```
TS2307: Cannot find module '@agentcommercekit/keys'
TS2305: Module 'agentcommercekit' has no exported member 'generateKeypair'
```

These look like real source regressions but are pure ordering artifacts.

## Fix

The umbrella `agentcommercekit` package transitively depends on every published package, so anchoring lint on `agentcommercekit#build` forces the full build graph (via its own `^build`) to complete before lint starts — regardless of invocation order. Root `^build` can't be used here because the workspace-root package.json has no dependencies, so it fans out to nothing.

## Verification

- `turbo check --force` — before: 87 type errors / fails; after: **29/29 tasks pass, 0 errors**
- `pnpm run check` (normal path) — 29/29 pass, lint 0 warnings/0 errors
- `oxfmt --check` — clean

## AI usage disclosure

Per [AI_POLICY.md](../blob/main/AI_POLICY.md): authored with **Claude Code** (Opus 4.8). Claude diagnosed the stale-`dist/` race, identified the umbrella-anchor fix, and verified it; changes were reviewed by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project workflow so linting now runs after a required build step, helping keep checks more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->