### PR TITLE
refactor(ack-pay): extract and harden expiresAt timestamp schema

### DIFF
--- a/.changeset/dedupe-timestamp-schema.md
+++ b/.changeset/dedupe-timestamp-schema.md
@@ -1,0 +1,12 @@
+---
+"@agentcommercekit/ack-pay": patch
+---
+
+Reject invalid `expiresAt` values in `paymentRequestSchema` instead of throwing.
+
+Previously the `expiresAt` transform called `new Date(input).toISOString()`
+directly, so an unparseable value (e.g. `"invalid-date"`) threw a `RangeError`
+out of `safeParse` rather than producing a validation error. A shared
+`timestampSchema` now validates the date is parseable before normalizing it to
+an ISO string, and the valibot and zod schemas share the same accept/reject
+behavior.

--- a/packages/ack-pay/src/schemas.test.ts
+++ b/packages/ack-pay/src/schemas.test.ts
@@ -1,0 +1,46 @@
+import * as v from "valibot"
+import { describe, expect, it } from "vitest"
+
+import { paymentRequestSchema as valibotPaymentRequestSchema } from "./schemas/valibot"
+import { paymentRequestSchema as zodPaymentRequestSchema } from "./schemas/zod"
+
+const paymentRequest = {
+  id: "test-payment-request-id",
+  paymentOptions: [
+    {
+      id: "test-payment-option-id",
+      amount: 10,
+      decimals: 2,
+      currency: "USD",
+      recipient: "sol:123",
+    },
+  ],
+}
+
+describe("paymentRequestSchema", () => {
+  it("rejects invalid expiresAt strings instead of throwing", () => {
+    const input = {
+      ...paymentRequest,
+      expiresAt: "invalid-date",
+    }
+
+    expect(v.safeParse(valibotPaymentRequestSchema, input).success).toBe(false)
+    expect(zodPaymentRequestSchema.safeParse(input).success).toBe(false)
+  })
+
+  it("normalizes valid expiresAt inputs to an ISO string", () => {
+    const expected = "2024-12-31T23:59:59.000Z"
+    for (const expiresAt of [
+      new Date("2024-12-31T23:59:59Z"),
+      "2024-12-31T23:59:59Z",
+    ]) {
+      const input = { ...paymentRequest, expiresAt }
+
+      const valibot = v.safeParse(valibotPaymentRequestSchema, input)
+      expect(valibot.success && valibot.output.expiresAt).toBe(expected)
+
+      const zod = zodPaymentRequestSchema.safeParse(input)
+      expect(zod.success && zod.data.expiresAt).toBe(expected)
+    }
+  })
+})

--- a/packages/ack-pay/src/schemas/valibot.ts
+++ b/packages/ack-pay/src/schemas/valibot.ts
@@ -4,6 +4,12 @@ import * as v from "valibot"
 
 const urlOrDidUri = v.union([v.pipe(v.string(), v.url()), didUriSchema])
 
+const timestampSchema = v.pipe(
+  v.union([v.date(), v.string()]),
+  v.check((input) => !Number.isNaN(new Date(input).getTime()), "Invalid date"),
+  v.transform((input) => new Date(input).toISOString()),
+)
+
 export const paymentOptionSchema = v.object({
   id: v.string(),
   amount: v.union([v.pipe(v.number(), v.integer(), v.gtValue(0)), v.string()]),
@@ -19,12 +25,7 @@ export const paymentRequestSchema = v.object({
   id: v.string(),
   description: v.optional(v.string()),
   serviceCallback: v.optional(v.pipe(v.string(), v.url())),
-  expiresAt: v.optional(
-    v.pipe(
-      v.union([v.date(), v.string()]),
-      v.transform((input) => new Date(input).toISOString()),
-    ),
-  ),
+  expiresAt: v.optional(timestampSchema),
   paymentOptions: v.pipe(
     v.tupleWithRest([paymentOptionSchema], paymentOptionSchema),
     v.nonEmpty(),

--- a/packages/ack-pay/src/schemas/zod.ts
+++ b/packages/ack-pay/src/schemas/zod.ts
@@ -4,6 +4,22 @@ import * as z from "zod"
 
 const urlOrDidUri = z.union([z.url(), didUriSchema])
 
+const timestampSchema = z
+  .union([z.date(), z.string()])
+  .transform((val, ctx) => {
+    const date = new Date(val)
+    if (Number.isNaN(date.getTime())) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Invalid date",
+        input: val,
+      })
+      return z.NEVER
+    }
+
+    return date.toISOString()
+  })
+
 export const paymentOptionSchema = z.object({
   id: z.string(),
   amount: z.union([z.number().int().positive(), z.string()]),
@@ -19,10 +35,7 @@ export const paymentRequestSchema = z.object({
   id: z.string(),
   description: z.string().optional(),
   serviceCallback: z.url().optional(),
-  expiresAt: z
-    .union([z.date(), z.string()])
-    .transform((val) => new Date(val).toISOString())
-    .optional(),
+  expiresAt: timestampSchema.optional(),
   paymentOptions: z.array(paymentOptionSchema).nonempty(),
 })
 


### PR DESCRIPTION
## Summary

Revives #104 (closed after #116 changed the schema layout), rescoped to the current `valibot.ts` + `zod.ts` layout — @venables invited a fresh PR against the new layout.

- Extract a shared `timestampSchema` for `paymentRequestSchema.expiresAt`
- **Reject unparseable dates** instead of throwing: previously `expiresAt` transformed via `new Date(input).toISOString()` directly, so a value like `"invalid-date"` threw a `RangeError` out of `safeParse` rather than producing a validation error
- Keep valibot and zod in accept/reject parity
- Add `schemas.test.ts` covering both the rejection path and the happy-path normalization to ISO across both schemas (the load-bearing transform, per @venables' request on #104)

## Why

`new Date("invalid").toISOString()` throws a `RangeError`. Callers using `safeParse` expect a `{ success: false }` result, not an exception. The shared schema validates the date is parseable before normalizing.

## Verification

- `pnpm run build`
- `pnpm run check` (build + format + type-aware lint + typecheck + test) — all green, lint 0/0
- `pnpm --filter @agentcommercekit/ack-pay test` — 36 passing (incl. new `schemas.test.ts`)

## Notes

Kept the permissive `new Date()` parse check rather than valibot's `isoTimestamp` / zod's `.datetime()` — narrowing the accepted `expiresAt` set to ISO-only is a deliberate contract change and out of scope for this dedup, same rationale as on #104. Happy to follow up with a stricter, parity-matched version if preferred.

## AI Usage Disclosure

This contribution was AI-assisted using Claude Code (Claude Opus). AI assistance was used to port the original #104 change onto the new schema layout, adapt the test to the two-schema (valibot + zod) structure, and run verification (`pnpm run check`). I reviewed the final diff and understand what it does — it validates `expiresAt` is a parseable date before normalizing to an ISO string, keeping valibot and zod in parity — and take responsibility for the submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid `expiresAt` values now fail validation cleanly instead of causing runtime errors.
  * Date inputs are now handled consistently, with valid values converted to ISO timestamps and invalid ones rejected.
* **Tests**
  * Added coverage for both schema implementations to verify invalid dates are rejected and valid dates are normalized correctly.
* **Documentation**
  * Added a release note entry describing the schema behavior update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->