### PR TITLE
feat(did): add optional fetch timeout to the did:web resolver

### DIFF
--- a/.changeset/did-web-resolver-fetch-timeout.md
+++ b/.changeset/did-web-resolver-fetch-timeout.md
@@ -2,9 +2,11 @@
 "@agentcommercekit/did": minor
 ---
 
-Add an optional `timeout` to `getResolver`'s `DidWebResolverOptions` for the
-`did:web` resolver. Resolving a `did:web` DID fetches the host named in the
-DID, so an unresponsive or slow host could otherwise hang the caller
-indefinitely. When set, the resolver passes `AbortSignal.timeout(timeout)` to
-the underlying fetch. Omitting it keeps the previous behaviour (no timeout),
-so this change is backward compatible.
+Add a `timeout` option to `getResolver`'s `DidWebResolverOptions` for the
+`did:web` resolver, defaulting to 5000ms. Resolving a `did:web` DID fetches
+the host named in the DID, so an unresponsive or slow host could otherwise
+hang the caller indefinitely. The resolver passes `AbortSignal.timeout(timeout)`
+to the underlying fetch; a custom `fetch` must honour `init.signal` for the
+timeout to take effect. Invalid values (zero, negative, non-integer or
+non-finite) throw a `RangeError`. There is no opt-out: every resolution now
+carries a deadline.

--- a/.changeset/did-web-resolver-fetch-timeout.md
+++ b/.changeset/did-web-resolver-fetch-timeout.md
@@ -1,0 +1,10 @@
+---
+"@agentcommercekit/did": minor
+---
+
+Add an optional `timeout` to `getResolver`'s `DidWebResolverOptions` for the
+`did:web` resolver. Resolving a `did:web` DID fetches the host named in the
+DID, so an unresponsive or slow host could otherwise hang the caller
+indefinitely. When set, the resolver passes `AbortSignal.timeout(timeout)` to
+the underlying fetch. Omitting it keeps the previous behaviour (no timeout),
+so this change is backward compatible.

--- a/.changeset/did-web-resolver-fetch-timeout.md
+++ b/.changeset/did-web-resolver-fetch-timeout.md
@@ -7,6 +7,8 @@ Add a `timeout` option to `getResolver`'s `DidWebResolverOptions` for the
 the host named in the DID, so an unresponsive or slow host could otherwise
 hang the caller indefinitely. The resolver passes `AbortSignal.timeout(timeout)`
 to the underlying fetch; a custom `fetch` must honour `init.signal` for the
-timeout to take effect. Invalid values (zero, negative, non-integer or
-non-finite) throw a `RangeError`. There is no opt-out: every resolution now
-carries a deadline.
+timeout to take effect. Values outside 1..2147483647 (the 32-bit
+timer limit) throw a `RangeError`: beyond it, runtimes either clamp the timer
+to 1ms or throw at fetch time, both of which would surface as a misleading
+`notFound`. There is no first-class opt-out; passing the maximum (about 24.8
+days) effectively disables the timeout.

--- a/packages/did/src/did-resolvers/web-did-resolver.test.ts
+++ b/packages/did/src/did-resolvers/web-did-resolver.test.ts
@@ -60,7 +60,7 @@ describe("web-did-resolver", () => {
       })
       expect(mockFetch).toHaveBeenCalledWith(
         "https://example.com/.well-known/did.json",
-        { mode: "cors" },
+        { mode: "cors", signal: expect.any(AbortSignal) },
       )
     })
 
@@ -92,7 +92,7 @@ describe("web-did-resolver", () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         "https://example.com/custom/path/did.json",
-        { mode: "cors" },
+        { mode: "cors", signal: expect.any(AbortSignal) },
       )
     })
 
@@ -125,7 +125,7 @@ describe("web-did-resolver", () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         "http://localhost:8787/.well-known/did.json",
-        { mode: "cors" },
+        { mode: "cors", signal: expect.any(AbortSignal) },
       )
     })
 
@@ -161,7 +161,7 @@ describe("web-did-resolver", () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         "https://example.com/issuers/v1/did.json",
-        { mode: "cors" },
+        { mode: "cors", signal: expect.any(AbortSignal) },
       )
     })
 
@@ -197,7 +197,7 @@ describe("web-did-resolver", () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         "http://localhost:8787/issuers/v1/did.json",
-        { mode: "cors" },
+        { mode: "cors", signal: expect.any(AbortSignal) },
       )
     })
 
@@ -414,11 +414,12 @@ describe("web-did-resolver", () => {
       timeoutSpy.mockRestore()
     })
 
-    it("does not pass a signal when no timeout is set", async () => {
+    it("applies the 5000ms default timeout when none is set", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve(mockDidDocument),
       })
+      const timeoutSpy = vi.spyOn(AbortSignal, "timeout")
 
       const did = "did:web:example.com"
       const resolver = getResolver()
@@ -440,18 +441,22 @@ describe("web-did-resolver", () => {
         {},
       )
 
-      // Exact init, so this fails if a signal (or anything else) is added.
+      expect(timeoutSpy).toHaveBeenCalledWith(5000)
       expect(mockFetch).toHaveBeenCalledWith(
         "https://example.com/.well-known/did.json",
-        { mode: "cors" },
+        expect.objectContaining({
+          mode: "cors",
+          signal: expect.any(AbortSignal),
+        }),
       )
+      timeoutSpy.mockRestore()
     })
 
     it("throws for an invalid timeout", () => {
-      expect(() => getResolver({ timeout: 0 })).toThrow(TypeError)
-      expect(() => getResolver({ timeout: -1 })).toThrow(TypeError)
-      expect(() => getResolver({ timeout: 1.5 })).toThrow(TypeError)
-      expect(() => getResolver({ timeout: NaN })).toThrow(TypeError)
+      expect(() => getResolver({ timeout: 0 })).toThrow(RangeError)
+      expect(() => getResolver({ timeout: -1 })).toThrow(RangeError)
+      expect(() => getResolver({ timeout: 1.5 })).toThrow(RangeError)
+      expect(() => getResolver({ timeout: NaN })).toThrow(RangeError)
     })
 
     it("surfaces a timed-out fetch as a notFound resolution error", async () => {

--- a/packages/did/src/did-resolvers/web-did-resolver.test.ts
+++ b/packages/did/src/did-resolvers/web-did-resolver.test.ts
@@ -457,6 +457,7 @@ describe("web-did-resolver", () => {
       expect(() => getResolver({ timeout: -1 })).toThrow(RangeError)
       expect(() => getResolver({ timeout: 1.5 })).toThrow(RangeError)
       expect(() => getResolver({ timeout: NaN })).toThrow(RangeError)
+      expect(() => getResolver({ timeout: 2147483648 })).toThrow(RangeError)
     })
 
     it("surfaces a timed-out fetch as a notFound resolution error", async () => {

--- a/packages/did/src/did-resolvers/web-did-resolver.test.ts
+++ b/packages/did/src/did-resolvers/web-did-resolver.test.ts
@@ -375,5 +375,115 @@ describe("web-did-resolver", () => {
       expect(customFetch).toHaveBeenCalled()
       expect(mockFetch).not.toHaveBeenCalled()
     })
+
+    it("passes an abort signal built from the configured timeout", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockDidDocument),
+      })
+      const timeoutSpy = vi.spyOn(AbortSignal, "timeout")
+
+      const did = "did:web:example.com"
+      const resolver = getResolver({ timeout: 5000 })
+      const parsedDid: ParsedDID = {
+        did,
+        didUrl: did,
+        method: "web",
+        id: "example.com",
+      }
+      await resolver.web(
+        did,
+        parsedDid,
+        {
+          resolve:
+            vi.fn<
+              (didUrl: string, options?: object) => Promise<DIDResolutionResult>
+            >(),
+        },
+        {},
+      )
+
+      expect(timeoutSpy).toHaveBeenCalledWith(5000)
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://example.com/.well-known/did.json",
+        expect.objectContaining({
+          mode: "cors",
+          signal: expect.any(AbortSignal),
+        }),
+      )
+      timeoutSpy.mockRestore()
+    })
+
+    it("does not pass a signal when no timeout is set", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockDidDocument),
+      })
+
+      const did = "did:web:example.com"
+      const resolver = getResolver()
+      const parsedDid: ParsedDID = {
+        did,
+        didUrl: did,
+        method: "web",
+        id: "example.com",
+      }
+      await resolver.web(
+        did,
+        parsedDid,
+        {
+          resolve:
+            vi.fn<
+              (didUrl: string, options?: object) => Promise<DIDResolutionResult>
+            >(),
+        },
+        {},
+      )
+
+      // Exact init, so this fails if a signal (or anything else) is added.
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://example.com/.well-known/did.json",
+        { mode: "cors" },
+      )
+    })
+
+    it("throws for an invalid timeout", () => {
+      expect(() => getResolver({ timeout: 0 })).toThrow(TypeError)
+      expect(() => getResolver({ timeout: -1 })).toThrow(TypeError)
+      expect(() => getResolver({ timeout: 1.5 })).toThrow(TypeError)
+      expect(() => getResolver({ timeout: NaN })).toThrow(TypeError)
+    })
+
+    it("surfaces a timed-out fetch as a notFound resolution error", async () => {
+      mockFetch.mockRejectedValueOnce(
+        new DOMException("The operation timed out.", "TimeoutError"),
+      )
+
+      const did = "did:web:example.com"
+      const resolver = getResolver({ timeout: 1 })
+      const parsedDid: ParsedDID = {
+        did,
+        didUrl: did,
+        method: "web",
+        id: "example.com",
+      }
+      const result = await resolver.web(
+        did,
+        parsedDid,
+        {
+          resolve:
+            vi.fn<
+              (didUrl: string, options?: object) => Promise<DIDResolutionResult>
+            >(),
+        },
+        {},
+      )
+
+      expect(result.didDocument).toBeNull()
+      expect(result.didResolutionMetadata.error).toBe("notFound")
+      expect(result.didResolutionMetadata.message).toContain(
+        "The operation timed out.",
+      )
+    })
   })
 })

--- a/packages/did/src/did-resolvers/web-did-resolver.ts
+++ b/packages/did/src/did-resolvers/web-did-resolver.ts
@@ -45,7 +45,8 @@ export interface DidWebResolverOptions {
    */
   allowedHttpHosts?: string[]
   /**
-   * Milliseconds to wait for the DID document fetch before aborting.
+   * Milliseconds to wait for the DID document fetch before aborting. Must
+   * be a positive integer of at most 2147483647 (the 32-bit timer limit).
    *
    * The timeout is applied via an `AbortSignal` on the request. A custom
    * `fetch` must honour `init.signal` for it to take effect.
@@ -56,6 +57,7 @@ export interface DidWebResolverOptions {
 
 const DEFAULT_ALLOWED_HTTP_HOSTS: string[] = []
 const DEFAULT_DOC_PATH = "/.well-known/did.json"
+const MAX_TIMEOUT_MS = 2147483647
 
 /**
  * Get a did document from a url and validate that it is a DidDocument
@@ -158,11 +160,15 @@ export function getResolver({
   timeout = 5000,
 }: DidWebResolverOptions = {}): { web: DIDResolver } {
   // Fail fast on a bad timeout rather than surfacing it later as a
-  // misleading `notFound` resolution error: `AbortSignal.timeout` throws on
-  // negative, non-integer or non-finite values, and 0, while legal for the
-  // API, would abort every request before it starts.
-  if (timeout <= 0 || !Number.isInteger(timeout)) {
-    throw new RangeError("`timeout` must be a positive integer (milliseconds)")
+  // misleading `notFound` resolution error. `AbortSignal.timeout` throws on
+  // negative, non-integer or non-finite values; 0 is legal for the API but
+  // would abort every request before it starts; and values beyond the
+  // 32-bit timer range either clamp the timer to 1ms or throw at fetch
+  // time, depending on the runtime.
+  if (timeout <= 0 || timeout > MAX_TIMEOUT_MS || !Number.isInteger(timeout)) {
+    throw new RangeError(
+      "`timeout` must be a positive integer of at most 2147483647 milliseconds",
+    )
   }
 
   async function resolve(

--- a/packages/did/src/did-resolvers/web-did-resolver.ts
+++ b/packages/did/src/did-resolvers/web-did-resolver.ts
@@ -45,13 +45,11 @@ export interface DidWebResolverOptions {
    */
   allowedHttpHosts?: string[]
   /**
-   * Milliseconds to wait for the DID document fetch before aborting. A
-   * `did:web` resolution fetches the host named in the DID, so an
-   * unresponsive host would otherwise hang the caller indefinitely. Omit to
-   * keep the previous behaviour (no timeout).
+   * Milliseconds to wait for the DID document fetch before aborting.
    *
    * The timeout is applied via an `AbortSignal` on the request. A custom
    * `fetch` must honour `init.signal` for it to take effect.
+   * @default 5000
    */
   timeout?: number
 }
@@ -157,13 +155,14 @@ export function getResolver({
   docPath = DEFAULT_DOC_PATH,
   fetch = globalThis.fetch,
   allowedHttpHosts = DEFAULT_ALLOWED_HTTP_HOSTS,
-  timeout,
+  timeout = 5000,
 }: DidWebResolverOptions = {}): { web: DIDResolver } {
-  // Fail fast on a bad timeout: `AbortSignal.timeout` throws on non-positive,
-  // non-integer or non-finite values, and that would otherwise surface as a
-  // misleading `notFound` resolution error rather than a programmer error.
-  if (timeout !== undefined && (!Number.isInteger(timeout) || timeout <= 0)) {
-    throw new TypeError("`timeout` must be a positive integer (milliseconds)")
+  // Fail fast on a bad timeout rather than surfacing it later as a
+  // misleading `notFound` resolution error: `AbortSignal.timeout` throws on
+  // negative, non-integer or non-finite values, and 0, while legal for the
+  // API, would abort every request before it starts.
+  if (timeout <= 0 || !Number.isInteger(timeout)) {
+    throw new RangeError("`timeout` must be a positive integer (milliseconds)")
   }
 
   async function resolve(

--- a/packages/did/src/did-resolvers/web-did-resolver.ts
+++ b/packages/did/src/did-resolvers/web-did-resolver.ts
@@ -44,6 +44,16 @@ export interface DidWebResolverOptions {
    * @default []
    */
   allowedHttpHosts?: string[]
+  /**
+   * Milliseconds to wait for the DID document fetch before aborting. A
+   * `did:web` resolution fetches the host named in the DID, so an
+   * unresponsive host would otherwise hang the caller indefinitely. Omit to
+   * keep the previous behaviour (no timeout).
+   *
+   * The timeout is applied via an `AbortSignal` on the request. A custom
+   * `fetch` must honour `init.signal` for it to take effect.
+   */
+  timeout?: number
 }
 
 const DEFAULT_ALLOWED_HTTP_HOSTS: string[] = []
@@ -57,9 +67,15 @@ const DEFAULT_DOC_PATH = "/.well-known/did.json"
  */
 async function fetchDidDocumentAtUrl(
   url: string | URL,
-  { fetch = globalThis.fetch }: { fetch?: FetchLike } = {},
+  {
+    fetch = globalThis.fetch,
+    timeout,
+  }: { fetch?: FetchLike; timeout?: number } = {},
 ): Promise<DidDocument> {
-  const res = await fetch(url, { mode: "cors" })
+  const res = await fetch(url, {
+    mode: "cors",
+    ...(timeout !== undefined ? { signal: AbortSignal.timeout(timeout) } : {}),
+  })
 
   if (!res.ok) {
     throw new Error(
@@ -141,7 +157,15 @@ export function getResolver({
   docPath = DEFAULT_DOC_PATH,
   fetch = globalThis.fetch,
   allowedHttpHosts = DEFAULT_ALLOWED_HTTP_HOSTS,
+  timeout,
 }: DidWebResolverOptions = {}): { web: DIDResolver } {
+  // Fail fast on a bad timeout: `AbortSignal.timeout` throws on non-positive,
+  // non-integer or non-finite values, and that would otherwise surface as a
+  // misleading `notFound` resolution error rather than a programmer error.
+  if (timeout !== undefined && (!Number.isInteger(timeout) || timeout <= 0)) {
+    throw new TypeError("`timeout` must be a positive integer (milliseconds)")
+  }
+
   async function resolve(
     did: string,
     parsed: ParsedDID,
@@ -155,7 +179,7 @@ export function getResolver({
     let didDocument: DIDDocument | null = null
 
     try {
-      didDocument = await fetchDidDocumentAtUrl(url, { fetch })
+      didDocument = await fetchDidDocumentAtUrl(url, { fetch, timeout })
 
       if (!isDidDocumentForDid(didDocument, did)) {
         throw new Error("DID document id does not match requested did")


### PR DESCRIPTION
## What
Adds an optional `timeout` (ms) to `DidWebResolverOptions` / `getResolver` for
the `did:web` resolver. When set, the resolver passes
`AbortSignal.timeout(timeout)` to the underlying fetch.

## Why
Resolving a `did:web` DID fetches the host named in the DID. Today
`fetchDidDocumentAtUrl` calls `fetch(url, { mode: "cors" })` with no
`AbortSignal`, so an unresponsive or slow host hangs the resolver
indefinitely. The resolver's own header comment says it exists for "additional
checks and more control for fetching and resolution", so a bounded fetch fits
its purpose. This is resource-exhaustion hardening, not an SSRF fix (did:web
inherently fetches the domain named in the DID).

## Change
- `timeout?: number` on `DidWebResolverOptions`
- threaded through `getResolver` -> `resolve` -> `fetchDidDocumentAtUrl`
- omitted = no timeout, so existing behaviour is unchanged (backward compatible)

## Tests
Three new tests in `web-did-resolver.test.ts`: the resolver builds the signal
from the configured timeout (`AbortSignal.timeout` is called with the value),
passes no signal when the option is omitted, and surfaces an aborted/timed-out
fetch as the standard `notFound` resolution error.
`pnpm --filter @agentcommercekit/did test` -> 73 passing. Changeset included
(minor). A response-size cap is a natural follow-up but needs body streaming,
so it is out of scope here.


## AI assistance disclosure
Per the repository AI policy: implemented and tested by gpt 5.6-sol and fable 5, then reviewed and understood by me. I can explain the implementation and its trade-offs without AI aid. Tests, typecheck, and formatting pass locally against the package suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `timeout` setting for `did:web` resolution requests (defaults to 5000ms).
  * Resolver requests are automatically cancelled when the timeout elapses (by wiring an `AbortSignal` to the fetch call).
* **Bug Fixes**
  * Invalid `timeout` values now fail fast with a clear `RangeError` (valid range: `1..2147483647`).
  * Timeout failures surface as a `notFound` resolution result with timeout-related error details.
* **Documentation**
  * Updated resolver docs to clarify timeout behavior and limitations.
* **Tests**
  * Updated/added unit tests covering signal wiring, default timeout, invalid values, and timeout error mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->