### PR TITLE
feat(jwt)!: require aud when an audience is expected

### DIFF
--- a/.changeset/jwt-require-audience.md
+++ b/.changeset/jwt-require-audience.md
@@ -1,0 +1,9 @@
+---
+"@agentcommercekit/jwt": minor
+---
+
+Add an optional `requireAudience` to `verifyJwt`. `did-jwt` only validates the
+`aud` claim when the token carries one, so a token that omits `aud` verifies
+even when the caller supplies an `audience`, allowing cross-service replay.
+Setting `requireAudience: true` rejects tokens with no audience. It defaults to
+off, so existing behaviour is unchanged.

--- a/.changeset/jwt-require-audience.md
+++ b/.changeset/jwt-require-audience.md
@@ -1,9 +1,15 @@
 ---
 "@agentcommercekit/jwt": minor
+"@agentcommercekit/ack-id": patch
 ---
 
-Add an optional `requireAudience` to `verifyJwt`. `did-jwt` only validates the
-`aud` claim when the token carries one, so a token that omits `aud` verifies
-even when the caller supplies an `audience`, allowing cross-service replay.
-Setting `requireAudience: true` rejects tokens with no audience. It defaults to
-off, so existing behaviour is unchanged.
+`verifyJwt` now fails when an `audience` is supplied and the token carries no
+non-empty `aud` claim, matching jose and PyJWT semantics. `did-jwt` only
+validates `aud` when the token carries one, so previously a token that omitted
+`aud` verified even when the caller expected an audience, allowing
+cross-service replay. There is no flag: supplying `audience` is the signal.
+Callers that accept audience-less tokens should omit the `audience` option.
+
+`verifyA2ASignedMessage` no longer passes `audience` to `verifyJwt`: signed
+A2A messages do not carry an `aud` claim, so the option never provided any
+check there. The handshake flow is unchanged and still verifies `aud`.

--- a/packages/ack-id/src/a2a/verify.test.ts
+++ b/packages/ack-id/src/a2a/verify.test.ts
@@ -174,7 +174,7 @@ describe("verifyA2ASignedMessage", () => {
     expect(result.verified).toBe(true)
   })
 
-  it("requires audience=self and issuer=counterparty for signature verification", async () => {
+  it("requires issuer=counterparty for signature verification", async () => {
     mockValidSignature()
 
     await verifyA2ASignedMessage(signedMessage("hello", "the.sig"), {
@@ -182,8 +182,9 @@ describe("verifyA2ASignedMessage", () => {
       counterparty: userDid,
     })
 
+    // Signed messages carry no aud claim today, so no audience is expected;
+    // the handshake flow embeds and verifies aud.
     expect(verifyJwt).toHaveBeenCalledWith("the.sig", {
-      audience: agentDid,
       issuer: userDid,
       resolver: expect.anything(),
     })

--- a/packages/ack-id/src/a2a/verify.ts
+++ b/packages/ack-id/src/a2a/verify.ts
@@ -74,9 +74,11 @@ export async function verifyA2ASignedMessage(
   } = v.parse(messageWithSignatureSchema, message)
 
   // Parse the signature from the message metadata, ensuring it is
-  // signed by the counterparty and intended for the provided DID
+  // signed by the counterparty. Signed messages do not carry an `aud`
+  // claim today (`createSignedA2AMessage` has no recipient parameter), so
+  // no audience is expected here; the handshake path above does embed and
+  // verify `aud`.
   const verified = await verifyJwt(metadata.sig, {
-    audience: did,
     issuer: counterparty,
     resolver,
   })

--- a/packages/ack-id/src/a2a/verify.ts
+++ b/packages/ack-id/src/a2a/verify.ts
@@ -62,7 +62,9 @@ export async function verifyA2AHandshakeMessage(
 
 export async function verifyA2ASignedMessage(
   message: Message,
-  { did, counterparty, resolver = getDidResolver() }: VerifyA2AHandshakeOptions,
+  // `did` stays in the options type for callers, but signed messages carry
+  // no `aud` claim today, so there is nothing to verify it against.
+  { counterparty, resolver = getDidResolver() }: VerifyA2AHandshakeOptions,
 ): Promise<JwtVerified> {
   // Ensure the message is a valid A2A signed message
   // We need to remove the auto-generated contextId from the message

--- a/packages/jwt/src/verify.test.ts
+++ b/packages/jwt/src/verify.test.ts
@@ -154,8 +154,9 @@ describe("verifyJwt()", () => {
     expect(result.payload.aud).toBe("did:example:audience")
   })
 
-  it.each([
-    { label: "an empty array", aud: [] as string[] },
+  it.each<{ label: string; aud: string | string[] | undefined }>([
+    { label: "missing", aud: undefined },
+    { label: "an empty array", aud: [] },
     { label: "an empty string", aud: "" },
     { label: "an array with only an empty string", aud: [""] },
   ])(
@@ -171,7 +172,7 @@ describe("verifyJwt()", () => {
         payload: {
           iss: "did:example:issuer",
           sub: "did:example:subject",
-          aud,
+          ...(aud === undefined ? {} : { aud }),
         },
         didResolutionResult: {
           didResolutionMetadata: {},
@@ -196,36 +197,6 @@ describe("verifyJwt()", () => {
     },
   )
 
-  it("throws when an audience is expected and the aud claim is missing", async () => {
-    const jwt = await createJwt(
-      { sub: "did:example:subject" },
-      { issuer: "did:example:issuer", signer },
-    )
-
-    const mockVerifiedResult: JWTVerified = {
-      verified: true,
-      payload: { iss: "did:example:issuer", sub: "did:example:subject" },
-      didResolutionResult: {
-        didResolutionMetadata: {},
-        didDocument: null,
-        didDocumentMetadata: {},
-      },
-      issuer: "did:example:issuer",
-      signer: {
-        id: "did:example:issuer#key-1",
-        type: "Multikey",
-        controller: "did:example:issuer",
-        publicKeyHex: "02...",
-      },
-      jwt,
-    }
-
-    vi.mocked(verifyJWT).mockResolvedValueOnce(mockVerifiedResult)
-
-    await expect(
-      verifyJwt(jwt, { audience: "did:example:audience" }),
-    ).rejects.toThrow("JWT audience is required but missing")
-  })
 
   it("does not require an aud claim when no audience is expected", async () => {
     const jwt = await createJwt(

--- a/packages/jwt/src/verify.test.ts
+++ b/packages/jwt/src/verify.test.ts
@@ -154,40 +154,47 @@ describe("verifyJwt()", () => {
     expect(result.payload.aud).toBe("did:example:audience")
   })
 
-  it("throws when an audience is expected and the aud claim is an empty array", async () => {
-    const jwt = await createJwt(
-      { sub: "did:example:subject" },
-      { issuer: "did:example:issuer", signer },
-    )
+  it.each([
+    { label: "an empty array", aud: [] as string[] },
+    { label: "an empty string", aud: "" },
+    { label: "an array with only an empty string", aud: [""] },
+  ])(
+    "throws when an audience is expected and the aud claim is $label",
+    async ({ aud }) => {
+      const jwt = await createJwt(
+        { sub: "did:example:subject" },
+        { issuer: "did:example:issuer", signer },
+      )
 
-    const mockVerifiedResult: JWTVerified = {
-      verified: true,
-      payload: {
-        iss: "did:example:issuer",
-        sub: "did:example:subject",
-        aud: [],
-      },
-      didResolutionResult: {
-        didResolutionMetadata: {},
-        didDocument: null,
-        didDocumentMetadata: {},
-      },
-      issuer: "did:example:issuer",
-      signer: {
-        id: "did:example:issuer#key-1",
-        type: "Multikey",
-        controller: "did:example:issuer",
-        publicKeyHex: "02...",
-      },
-      jwt,
-    }
+      const mockVerifiedResult: JWTVerified = {
+        verified: true,
+        payload: {
+          iss: "did:example:issuer",
+          sub: "did:example:subject",
+          aud,
+        },
+        didResolutionResult: {
+          didResolutionMetadata: {},
+          didDocument: null,
+          didDocumentMetadata: {},
+        },
+        issuer: "did:example:issuer",
+        signer: {
+          id: "did:example:issuer#key-1",
+          type: "Multikey",
+          controller: "did:example:issuer",
+          publicKeyHex: "02...",
+        },
+        jwt,
+      }
 
-    vi.mocked(verifyJWT).mockResolvedValueOnce(mockVerifiedResult)
+      vi.mocked(verifyJWT).mockResolvedValueOnce(mockVerifiedResult)
 
-    await expect(
-      verifyJwt(jwt, { audience: "did:example:audience" }),
-    ).rejects.toThrow("JWT audience is required but missing")
-  })
+      await expect(
+        verifyJwt(jwt, { audience: "did:example:audience" }),
+      ).rejects.toThrow("JWT audience is required but missing")
+    },
+  )
 
   it("throws when an audience is expected and the aud claim is missing", async () => {
     const jwt = await createJwt(

--- a/packages/jwt/src/verify.test.ts
+++ b/packages/jwt/src/verify.test.ts
@@ -197,7 +197,6 @@ describe("verifyJwt()", () => {
     },
   )
 
-
   it("does not require an aud claim when no audience is expected", async () => {
     const jwt = await createJwt(
       { sub: "did:example:subject" },

--- a/packages/jwt/src/verify.test.ts
+++ b/packages/jwt/src/verify.test.ts
@@ -112,8 +112,8 @@ describe("verifyJwt()", () => {
   })
 
   it("forwards the audience and passes when the aud claim is present", async () => {
-    // The realistic path: the caller supplies `audience` (which did-jwt
-    // matches) and `requireAudience` on top (which rejects an absent aud).
+    // The realistic path: the caller supplies `audience`; did-jwt matches
+    // the value and verifyJwt rejects an absent aud.
     const jwt = await createJwt(
       { sub: "did:example:subject", aud: "did:example:audience" },
       { issuer: "did:example:issuer", signer },
@@ -145,21 +145,16 @@ describe("verifyJwt()", () => {
 
     const result = await verifyJwt(jwt, {
       audience: "did:example:audience",
-      requireAudience: true,
     })
 
-    // `audience` is forwarded to did-jwt, `requireAudience` is not.
     expect(verifyJWT).toHaveBeenCalledWith(
       jwt,
       expect.objectContaining({ audience: "did:example:audience" }),
     )
-    expect(vi.mocked(verifyJWT).mock.calls[0]?.[1]).not.toHaveProperty(
-      "requireAudience",
-    )
     expect(result.payload.aud).toBe("did:example:audience")
   })
 
-  it("throws when requireAudience is set and the aud claim is an empty array", async () => {
+  it("throws when an audience is expected and the aud claim is an empty array", async () => {
     const jwt = await createJwt(
       { sub: "did:example:subject" },
       { issuer: "did:example:issuer", signer },
@@ -189,12 +184,12 @@ describe("verifyJwt()", () => {
 
     vi.mocked(verifyJWT).mockResolvedValueOnce(mockVerifiedResult)
 
-    await expect(verifyJwt(jwt, { requireAudience: true })).rejects.toThrow(
-      "JWT audience is required but missing",
-    )
+    await expect(
+      verifyJwt(jwt, { audience: "did:example:audience" }),
+    ).rejects.toThrow("JWT audience is required but missing")
   })
 
-  it("throws when requireAudience is set and the aud claim is missing", async () => {
+  it("throws when an audience is expected and the aud claim is missing", async () => {
     const jwt = await createJwt(
       { sub: "did:example:subject" },
       { issuer: "did:example:issuer", signer },
@@ -220,9 +215,36 @@ describe("verifyJwt()", () => {
 
     vi.mocked(verifyJWT).mockResolvedValueOnce(mockVerifiedResult)
 
-    await expect(verifyJwt(jwt, { requireAudience: true })).rejects.toThrow(
-      "JWT audience is required but missing",
+    await expect(
+      verifyJwt(jwt, { audience: "did:example:audience" }),
+    ).rejects.toThrow("JWT audience is required but missing")
+  })
+
+  it("does not require an aud claim when no audience is expected", async () => {
+    const jwt = await createJwt(
+      { sub: "did:example:subject" },
+      { issuer: "did:example:issuer", signer },
     )
+
+    const mockVerifiedResult: JWTVerified = {
+      verified: true,
+      payload: { iss: "did:example:issuer", sub: "did:example:subject" },
+      didResolutionResult: {
+        didResolutionMetadata: {},
+        didDocument: null,
+        didDocumentMetadata: {},
+      },
+      issuer: "did:example:issuer",
+      signer: {
+        id: "did:example:issuer#key-1",
+        type: "JsonWebKey2020",
+        controller: "did:example:issuer",
+      },
+      jwt,
+    }
+    vi.mocked(verifyJWT).mockResolvedValueOnce(mockVerifiedResult)
+
+    await expect(verifyJwt(jwt)).resolves.toMatchObject({ verified: true })
   })
 
   it("throws error when issuer does not match expected issuer", async () => {

--- a/packages/jwt/src/verify.test.ts
+++ b/packages/jwt/src/verify.test.ts
@@ -20,6 +20,8 @@ describe("verifyJwt()", () => {
   let signer: ReturnType<typeof createJwtSigner>
 
   beforeEach(async () => {
+    // Clear call history so per-test call-index assertions see only this test.
+    vi.mocked(verifyJWT).mockClear()
     keypair = await generateKeypair("secp256k1")
     signer = createJwtSigner(keypair)
   })
@@ -107,6 +109,120 @@ describe("verifyJwt()", () => {
     })
 
     expect(result.payload.iss).toBe("did:example:issuer")
+  })
+
+  it("forwards the audience and passes when the aud claim is present", async () => {
+    // The realistic path: the caller supplies `audience` (which did-jwt
+    // matches) and `requireAudience` on top (which rejects an absent aud).
+    const jwt = await createJwt(
+      { sub: "did:example:subject", aud: "did:example:audience" },
+      { issuer: "did:example:issuer", signer },
+    )
+
+    const mockVerifiedResult: JWTVerified = {
+      verified: true,
+      payload: {
+        iss: "did:example:issuer",
+        sub: "did:example:subject",
+        aud: "did:example:audience",
+      },
+      didResolutionResult: {
+        didResolutionMetadata: {},
+        didDocument: null,
+        didDocumentMetadata: {},
+      },
+      issuer: "did:example:issuer",
+      signer: {
+        id: "did:example:issuer#key-1",
+        type: "Multikey",
+        controller: "did:example:issuer",
+        publicKeyHex: "02...",
+      },
+      jwt,
+    }
+
+    vi.mocked(verifyJWT).mockResolvedValueOnce(mockVerifiedResult)
+
+    const result = await verifyJwt(jwt, {
+      audience: "did:example:audience",
+      requireAudience: true,
+    })
+
+    // `audience` is forwarded to did-jwt, `requireAudience` is not.
+    expect(verifyJWT).toHaveBeenCalledWith(
+      jwt,
+      expect.objectContaining({ audience: "did:example:audience" }),
+    )
+    expect(vi.mocked(verifyJWT).mock.calls[0]?.[1]).not.toHaveProperty(
+      "requireAudience",
+    )
+    expect(result.payload.aud).toBe("did:example:audience")
+  })
+
+  it("throws when requireAudience is set and the aud claim is an empty array", async () => {
+    const jwt = await createJwt(
+      { sub: "did:example:subject" },
+      { issuer: "did:example:issuer", signer },
+    )
+
+    const mockVerifiedResult: JWTVerified = {
+      verified: true,
+      payload: {
+        iss: "did:example:issuer",
+        sub: "did:example:subject",
+        aud: [],
+      },
+      didResolutionResult: {
+        didResolutionMetadata: {},
+        didDocument: null,
+        didDocumentMetadata: {},
+      },
+      issuer: "did:example:issuer",
+      signer: {
+        id: "did:example:issuer#key-1",
+        type: "Multikey",
+        controller: "did:example:issuer",
+        publicKeyHex: "02...",
+      },
+      jwt,
+    }
+
+    vi.mocked(verifyJWT).mockResolvedValueOnce(mockVerifiedResult)
+
+    await expect(verifyJwt(jwt, { requireAudience: true })).rejects.toThrow(
+      "JWT audience is required but missing",
+    )
+  })
+
+  it("throws when requireAudience is set and the aud claim is missing", async () => {
+    const jwt = await createJwt(
+      { sub: "did:example:subject" },
+      { issuer: "did:example:issuer", signer },
+    )
+
+    const mockVerifiedResult: JWTVerified = {
+      verified: true,
+      payload: { iss: "did:example:issuer", sub: "did:example:subject" },
+      didResolutionResult: {
+        didResolutionMetadata: {},
+        didDocument: null,
+        didDocumentMetadata: {},
+      },
+      issuer: "did:example:issuer",
+      signer: {
+        id: "did:example:issuer#key-1",
+        type: "Multikey",
+        controller: "did:example:issuer",
+        publicKeyHex: "02...",
+      },
+      jwt,
+    }
+
+    vi.mocked(verifyJWT).mockResolvedValueOnce(mockVerifiedResult)
+
+    await expect(verifyJwt(jwt, { requireAudience: true })).rejects.toThrow(
+      "JWT audience is required but missing",
+    )
   })
 
   it("throws error when issuer does not match expected issuer", async () => {

--- a/packages/jwt/src/verify.ts
+++ b/packages/jwt/src/verify.ts
@@ -4,14 +4,6 @@ export type JwtVerified = JWTVerified
 
 export type VerifyJwtOptions = JWTVerifyOptions & {
   issuer?: string
-  /**
-   * Require the JWT to carry a non-empty `aud` claim. `did-jwt` only runs its
-   * audience check when the token has an `aud`, so a token that omits it is
-   * accepted even when an `audience` is supplied. Setting this ensures the
-   * audience check actually runs; supply `audience` for the value to be
-   * matched.
-   */
-  requireAudience?: boolean
 }
 
 /** Whether a JWT `aud` claim carries at least one non-empty audience. */
@@ -26,12 +18,16 @@ function hasAudience(aud: string | string[] | undefined): boolean {
 }
 
 /**
- * Verify a JWT, with additional options to restrict to a specific issuer and
- * to require an audience claim.
+ * Verify a JWT, with an additional option to restrict to a specific issuer.
+ *
+ * When an `audience` is supplied, a token without a non-empty `aud` claim
+ * fails verification. `did-jwt` only matches `aud` when the token carries
+ * one, so without this check a token that omits `aud` would verify even
+ * though the caller expected an audience.
  */
 export async function verifyJwt(
   jwt: string,
-  { issuer, requireAudience, ...options }: VerifyJwtOptions = {},
+  { issuer, ...options }: VerifyJwtOptions = {},
 ): Promise<JwtVerified> {
   const result = await verifyJWT(jwt, options)
 
@@ -39,7 +35,7 @@ export async function verifyJwt(
     throw new Error(`Expected issuer ${issuer}, got ${result.payload.iss}`)
   }
 
-  if (requireAudience && !hasAudience(result.payload.aud)) {
+  if (options.audience !== undefined && !hasAudience(result.payload.aud)) {
     throw new Error("JWT audience is required but missing")
   }
 

--- a/packages/jwt/src/verify.ts
+++ b/packages/jwt/src/verify.ts
@@ -4,19 +4,43 @@ export type JwtVerified = JWTVerified
 
 export type VerifyJwtOptions = JWTVerifyOptions & {
   issuer?: string
+  /**
+   * Require the JWT to carry a non-empty `aud` claim. `did-jwt` only runs its
+   * audience check when the token has an `aud`, so a token that omits it is
+   * accepted even when an `audience` is supplied. Setting this ensures the
+   * audience check actually runs; supply `audience` for the value to be
+   * matched.
+   */
+  requireAudience?: boolean
+}
+
+/** Whether a JWT `aud` claim carries at least one non-empty audience. */
+function hasAudience(aud: string | string[] | undefined): boolean {
+  if (typeof aud === "string") {
+    return aud.length > 0
+  }
+  if (Array.isArray(aud)) {
+    return aud.some((entry) => entry.length > 0)
+  }
+  return false
 }
 
 /**
- * Verify a JWT, with additional options to restrict to a specific issuer
+ * Verify a JWT, with additional options to restrict to a specific issuer and
+ * to require an audience claim.
  */
 export async function verifyJwt(
   jwt: string,
-  { issuer, ...options }: VerifyJwtOptions = {},
+  { issuer, requireAudience, ...options }: VerifyJwtOptions = {},
 ): Promise<JwtVerified> {
   const result = await verifyJWT(jwt, options)
 
   if (issuer && result.payload.iss !== issuer) {
     throw new Error(`Expected issuer ${issuer}, got ${result.payload.iss}`)
+  }
+
+  if (requireAudience && !hasAudience(result.payload.aud)) {
+    throw new Error("JWT audience is required but missing")
   }
 
   return result


### PR DESCRIPTION
## What
`verifyJwt` now fails a token whose `aud` claim is missing or empty whenever
the caller supplies an `audience`. No flag: supplying `audience` is the
signal, matching jose and PyJWT semantics (this PR originally added an
opt-in `requireAudience` boolean; reshaped per review).

## Why
`did-jwt`'s `verifyJWT` only runs its audience match when the token carries
an `aud` claim, so a token that omits `aud` verifies even when the caller
supplies an `audience`, allowing cross-service replay. jose throws
`ERR_JWT_CLAIM_VALIDATION_FAILED` (`reason: "missing"`) and PyJWT raises
`MissingRequiredClaimError` in the same situation; did-jwt is the outlier.
A quick code search also found an external consumer passing `audience` to
`verifyJwt` whose doc comment assumes `aud` is enforced, so the strict
default silently fixes real usage.

## A2A call sites
The two `ack-id` A2A verifiers turn out to differ:

- **Handshake** keeps `audience: did`: handshake JWTs have embedded
  `aud: params.recipient` since the original implementation
  (`sign-message.ts`), so the strict rule just works there.
- **Signed messages** drop `audience: did`: `createSignedA2AMessage` has no
  recipient parameter, its JWTs never carry `aud`, and the option never
  provided a check on that path. No behavior change.

Possible follow-up (separate PR if wanted): give `createSignedA2AMessage` a
recipient parameter and verify `aud` strictly on signed messages too. The
identity-a2a README already documents `aud` on signed messages as MITM
protection, but the code never implemented it. It changes that function's
signature; a code search finds no external consumers of the a2a module.

## Change
- `VerifyJwtOptions.requireAudience` removed; presence check keys on
  `options.audience`
- `hasAudience` helper unchanged (non-empty string or array with a
  non-empty entry)
- `verifyA2ASignedMessage` no longer passes `audience`
- changeset rewritten: `@agentcommercekit/jwt` minor (behavior change
  documented), `@agentcommercekit/ack-id` patch

## Tests
`packages/jwt`: expected-audience-with-matching-aud passes; missing and
empty-array `aud` reject; no-audience-expected accepts aud-less tokens.
`packages/ack-id`: handshake still asserts `audience`; signed-message
asserts no `audience` is passed. `pnpm run check` (build + lint + format +
all tests) green: jwt 22, ack-id 39.

## AI assistance disclosure
Per the repository AI policy: implemented and tested by gpt 5.6-sol and fable 5, then reviewed and understood by me. I can explain the implementation and its trade-offs without AI aid. Tests, typecheck, and formatting pass locally against the package suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated JWT verification so that when an expected audience is provided, verification fails if the token’s `aud` claim is missing or empty.
  * Adjusted signed A2A message verification so underlying JWT checks no longer expect an `aud` claim (handshake verification still validates `aud`).
* **Tests**
  * Strengthened audience-related test cases, including additional “aud missing/empty” scenarios, and fixed test isolation by clearing mock call history.
  * Updated A2A signed-message verification assertions to match the new contract.
* **Documentation**
  * Added a changeset describing the audience verification behavior update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->