### PR TITLE
feat(did): refuse redirects when resolving did:web by default

### DIFF
--- a/.changeset/wild-hounds-shave.md
+++ b/.changeset/wild-hounds-shave.md
@@ -7,5 +7,8 @@ Refuse redirects when resolving did:web documents by default
 `allowedHttpHosts` is checked against the URL built from the DID, but the
 fetch followed redirects, so a redirect could move the request to a host or
 scheme that check would have rejected. did:web documents are served directly
-at a well-known path, so the resolver now sends `redirect: "error"`. Set
-`followRedirects: true` to restore the previous behavior.
+at a well-known path, so the resolver now sends `redirect: "manual"` and
+refuses any redirect response with a precise error that names the redirect
+target when the runtime exposes it (Node does; browsers surface an opaque
+redirect without one). Set `followRedirects: true` to restore the previous
+behavior.

--- a/.changeset/wild-hounds-shave.md
+++ b/.changeset/wild-hounds-shave.md
@@ -2,13 +2,14 @@
 "@agentcommercekit/did": minor
 ---
 
-Refuse redirects when resolving did:web documents by default
+Refuse redirects when resolving did:web and did:jwks documents by default
 
 `allowedHttpHosts` is checked against the URL built from the DID, but the
 fetch followed redirects, so a redirect could move the request to a host or
-scheme that check would have rejected. did:web documents are served directly
-at a well-known path, so the resolver now sends `redirect: "manual"` and
-refuses any redirect response with a precise error that names the redirect
-target when the runtime exposes it (Node does; browsers surface an opaque
-redirect without one). Set `followRedirects: true` to restore the previous
+scheme that check would have rejected. DID documents are served directly at
+a well-known path, so the resolvers now send `redirect: "manual"`. The
+did:web resolver refuses any redirect response with a precise error that
+names the redirect target when the runtime exposes it (Node does; browsers
+surface an opaque redirect without one); a redirected did:jwks resolution
+fails as `notFound`. Set `followRedirects: true` to restore the previous
 behavior.

--- a/.changeset/wild-hounds-shave.md
+++ b/.changeset/wild-hounds-shave.md
@@ -1,0 +1,11 @@
+---
+"@agentcommercekit/did": minor
+---
+
+Refuse redirects when resolving did:web documents by default
+
+`allowedHttpHosts` is checked against the URL built from the DID, but the
+fetch followed redirects, so a redirect could move the request to a host or
+scheme that check would have rejected. did:web documents are served directly
+at a well-known path, so the resolver now sends `redirect: "error"`. Set
+`followRedirects: true` to restore the previous behavior.

--- a/packages/did/src/did-resolvers/get-did-resolver.test.ts
+++ b/packages/did/src/did-resolvers/get-did-resolver.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type { FetchLike } from "../types"
+import { getDidResolver } from "./get-did-resolver"
+
+describe("getDidResolver", () => {
+  describe("did:jwks redirect policy", () => {
+    it("refuses redirects by default when resolving did:jwks", async () => {
+      const mockFetch = vi
+        .fn<FetchLike>()
+        .mockResolvedValue(new Response(null, { status: 302 }))
+
+      const resolver = getDidResolver({ webOptions: { fetch: mockFetch } })
+      const result = await resolver.resolve("did:jwks:example.com")
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://example.com/.well-known/jwks.json",
+        expect.objectContaining({ redirect: "manual" }),
+      )
+      expect(result.didDocument).toBeNull()
+      expect(result.didResolutionMetadata.error).toBe("notFound")
+    })
+
+    it("follows redirects for did:jwks when followRedirects is true", async () => {
+      const mockFetch = vi
+        .fn<FetchLike>()
+        .mockResolvedValue(new Response(null, { status: 404 }))
+
+      const resolver = getDidResolver({
+        webOptions: { fetch: mockFetch, followRedirects: true },
+      })
+      await resolver.resolve("did:jwks:example.com")
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://example.com/.well-known/jwks.json",
+        expect.objectContaining({ redirect: "follow" }),
+      )
+    })
+
+    it("applies the redirect policy to the global fetch when no custom fetch is given", async () => {
+      const mockFetch = vi
+        .fn<FetchLike>()
+        .mockResolvedValue(new Response(null, { status: 302 }))
+      vi.stubGlobal("fetch", mockFetch)
+
+      try {
+        const resolver = getDidResolver()
+        await resolver.resolve("did:jwks:example.com")
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          "https://example.com/.well-known/jwks.json",
+          expect.objectContaining({ redirect: "manual" }),
+        )
+      } finally {
+        vi.unstubAllGlobals()
+      }
+    })
+  })
+})

--- a/packages/did/src/did-resolvers/get-did-resolver.ts
+++ b/packages/did/src/did-resolvers/get-did-resolver.ts
@@ -28,12 +28,17 @@ export function getDidResolver({
   },
   ...options
 }: GetDidResolverOptions = {}): DidResolver {
-  const webFetch = webOptions.fetch
+  const webFetch = webOptions.fetch ?? globalThis.fetch
   const keyResolver = getKeyDidResolver()
   const webResolver = getWebDidResolver(webOptions)
+  // did-jwks calls fetch with no init, so inject the redirect policy here
   const jwksResolver = getJwksDidResolver({
     ...webOptions,
-    fetch: webFetch ? (input, init) => webFetch(input, init) : globalThis.fetch,
+    fetch: (input, init) =>
+      webFetch(input, {
+        ...init,
+        redirect: webOptions.followRedirects ? "follow" : "manual",
+      }),
   })
   const pkhResolver = getPkhDidResolver()
 

--- a/packages/did/src/did-resolvers/web-did-resolver.test.ts
+++ b/packages/did/src/did-resolvers/web-did-resolver.test.ts
@@ -60,7 +60,7 @@ describe("web-did-resolver", () => {
       })
       expect(mockFetch).toHaveBeenCalledWith(
         "https://example.com/.well-known/did.json",
-        { mode: "cors" },
+        { mode: "cors", redirect: "error" },
       )
     })
 
@@ -92,7 +92,7 @@ describe("web-did-resolver", () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         "https://example.com/custom/path/did.json",
-        { mode: "cors" },
+        { mode: "cors", redirect: "error" },
       )
     })
 
@@ -125,7 +125,7 @@ describe("web-did-resolver", () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         "http://localhost:8787/.well-known/did.json",
-        { mode: "cors" },
+        { mode: "cors", redirect: "error" },
       )
     })
 
@@ -161,7 +161,7 @@ describe("web-did-resolver", () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         "https://example.com/issuers/v1/did.json",
-        { mode: "cors" },
+        { mode: "cors", redirect: "error" },
       )
     })
 
@@ -197,7 +197,7 @@ describe("web-did-resolver", () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         "http://localhost:8787/issuers/v1/did.json",
-        { mode: "cors" },
+        { mode: "cors", redirect: "error" },
       )
     })
 
@@ -343,6 +343,72 @@ describe("web-did-resolver", () => {
             "resolver_error: DID document id does not match requested did",
         },
       })
+    })
+
+    it("refuses redirects by default", async () => {
+      // The allowedHttpHosts check applies to the resolved URL only, so a
+      // followed redirect could reach a host or scheme it would reject.
+      mockFetch.mockRejectedValueOnce(
+        new TypeError("fetch failed: unexpected redirect"),
+      )
+
+      const did = "did:web:example.com"
+      const resolver = getResolver()
+      const parsedDid: ParsedDID = {
+        did,
+        didUrl: did,
+        method: "web",
+        id: "example.com",
+      }
+      const result = await resolver.web(
+        did,
+        parsedDid,
+        {
+          resolve:
+            vi.fn<
+              (didUrl: string, options?: object) => Promise<DIDResolutionResult>
+            >(),
+        },
+        {},
+      )
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://example.com/.well-known/did.json",
+        { mode: "cors", redirect: "error" },
+      )
+      expect(result.didResolutionMetadata.error).toBe("notFound")
+    })
+
+    it("follows redirects when followRedirects is true", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockDidDocument),
+      })
+
+      const did = "did:web:example.com"
+      const resolver = getResolver({ followRedirects: true })
+      const parsedDid: ParsedDID = {
+        did,
+        didUrl: did,
+        method: "web",
+        id: "example.com",
+      }
+      await resolver.web(
+        did,
+        parsedDid,
+        {
+          resolve:
+            vi.fn<
+              (didUrl: string, options?: object) => Promise<DIDResolutionResult>
+            >(),
+        },
+        {},
+      )
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://example.com/.well-known/did.json",
+        { mode: "cors", redirect: "follow" },
+      )
     })
 
     it("uses custom fetch function when provided", async () => {

--- a/packages/did/src/did-resolvers/web-did-resolver.test.ts
+++ b/packages/did/src/did-resolvers/web-did-resolver.test.ts
@@ -366,10 +366,6 @@ describe("web-did-resolver", () => {
     })
 
     it("refuses redirects by default and reports the redirect target", async () => {
-      // The allowedHttpHosts check applies to the resolved URL only, so a
-      // followed redirect could reach a host or scheme it would reject. With
-      // `redirect: "manual"` the redirect resolves instead of throwing, so
-      // the error can name the target from the Location header.
       mockFetch.mockResolvedValueOnce({
         status: 302,
         headers: {
@@ -413,8 +409,6 @@ describe("web-did-resolver", () => {
     })
 
     it("refuses an opaque browser redirect without a target", async () => {
-      // Browsers surface manual redirects as an opaque response with no
-      // readable status or headers.
       mockFetch.mockResolvedValueOnce({
         type: "opaqueredirect",
         status: 0,

--- a/packages/did/src/did-resolvers/web-did-resolver.test.ts
+++ b/packages/did/src/did-resolvers/web-did-resolver.test.ts
@@ -384,7 +384,7 @@ describe("web-did-resolver", () => {
       )
       expect(result.didResolutionMetadata.error).toBe("notFound")
       expect(result.didResolutionMetadata.message).toBe(
-        "resolver_error: DID resolution refused a redirect to http://internal.host/did.json",
+        "resolver_error: DID resolution refused a redirect to http://internal.host/did.json. Set followRedirects: true to allow redirects.",
       )
     })
 
@@ -419,7 +419,7 @@ describe("web-did-resolver", () => {
 
       expect(result.didResolutionMetadata.error).toBe("notFound")
       expect(result.didResolutionMetadata.message).toBe(
-        "resolver_error: DID resolution refused a redirect",
+        "resolver_error: DID resolution refused a redirect. Set followRedirects: true to allow redirects.",
       )
     })
 

--- a/packages/did/src/did-resolvers/web-did-resolver.test.ts
+++ b/packages/did/src/did-resolvers/web-did-resolver.test.ts
@@ -60,7 +60,7 @@ describe("web-did-resolver", () => {
       })
       expect(mockFetch).toHaveBeenCalledWith(
         "https://example.com/.well-known/did.json",
-        { mode: "cors", redirect: "error" },
+        { mode: "cors", redirect: "manual" },
       )
     })
 
@@ -92,7 +92,7 @@ describe("web-did-resolver", () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         "https://example.com/custom/path/did.json",
-        { mode: "cors", redirect: "error" },
+        { mode: "cors", redirect: "manual" },
       )
     })
 
@@ -125,7 +125,7 @@ describe("web-did-resolver", () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         "http://localhost:8787/.well-known/did.json",
-        { mode: "cors", redirect: "error" },
+        { mode: "cors", redirect: "manual" },
       )
     })
 
@@ -161,7 +161,7 @@ describe("web-did-resolver", () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         "https://example.com/issuers/v1/did.json",
-        { mode: "cors", redirect: "error" },
+        { mode: "cors", redirect: "manual" },
       )
     })
 
@@ -197,7 +197,7 @@ describe("web-did-resolver", () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         "http://localhost:8787/issuers/v1/did.json",
-        { mode: "cors", redirect: "error" },
+        { mode: "cors", redirect: "manual" },
       )
     })
 
@@ -345,12 +345,18 @@ describe("web-did-resolver", () => {
       })
     })
 
-    it("refuses redirects by default", async () => {
+    it("refuses redirects by default and reports the redirect target", async () => {
       // The allowedHttpHosts check applies to the resolved URL only, so a
-      // followed redirect could reach a host or scheme it would reject.
-      mockFetch.mockRejectedValueOnce(
-        new TypeError("fetch failed: unexpected redirect"),
-      )
+      // followed redirect could reach a host or scheme it would reject. With
+      // `redirect: "manual"` the redirect resolves instead of throwing, so
+      // the error can name the target from the Location header.
+      mockFetch.mockResolvedValueOnce({
+        status: 302,
+        headers: {
+          get: (name: string) =>
+            name === "location" ? "http://internal.host/did.json" : null,
+        },
+      })
 
       const did = "did:web:example.com"
       const resolver = getResolver()
@@ -374,9 +380,47 @@ describe("web-did-resolver", () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         "https://example.com/.well-known/did.json",
-        { mode: "cors", redirect: "error" },
+        { mode: "cors", redirect: "manual" },
       )
       expect(result.didResolutionMetadata.error).toBe("notFound")
+      expect(result.didResolutionMetadata.message).toBe(
+        "resolver_error: DID resolution refused a redirect to http://internal.host/did.json",
+      )
+    })
+
+    it("refuses an opaque browser redirect without a target", async () => {
+      // Browsers surface manual redirects as an opaque response with no
+      // readable status or headers.
+      mockFetch.mockResolvedValueOnce({
+        type: "opaqueredirect",
+        status: 0,
+        headers: { get: () => null },
+      })
+
+      const did = "did:web:example.com"
+      const resolver = getResolver()
+      const parsedDid: ParsedDID = {
+        did,
+        didUrl: did,
+        method: "web",
+        id: "example.com",
+      }
+      const result = await resolver.web(
+        did,
+        parsedDid,
+        {
+          resolve:
+            vi.fn<
+              (didUrl: string, options?: object) => Promise<DIDResolutionResult>
+            >(),
+        },
+        {},
+      )
+
+      expect(result.didResolutionMetadata.error).toBe("notFound")
+      expect(result.didResolutionMetadata.message).toBe(
+        "resolver_error: DID resolution refused a redirect",
+      )
     })
 
     it("follows redirects when followRedirects is true", async () => {

--- a/packages/did/src/did-resolvers/web-did-resolver.ts
+++ b/packages/did/src/did-resolvers/web-did-resolver.ts
@@ -44,6 +44,17 @@ export interface DidWebResolverOptions {
    * @default []
    */
   allowedHttpHosts?: string[]
+  /**
+   * Whether to follow HTTP redirects while fetching the did document.
+   *
+   * The `allowedHttpHosts` check applies to the resolved URL only, so a
+   * followed redirect can move the request to a host or scheme that check
+   * would have rejected. did:web documents are served directly at a
+   * well-known path, so redirects are refused by default.
+   *
+   * @default false
+   */
+  followRedirects?: boolean
 }
 
 const DEFAULT_ALLOWED_HTTP_HOSTS: string[] = []
@@ -57,9 +68,15 @@ const DEFAULT_DOC_PATH = "/.well-known/did.json"
  */
 async function fetchDidDocumentAtUrl(
   url: string | URL,
-  { fetch = globalThis.fetch }: { fetch?: FetchLike } = {},
+  {
+    fetch = globalThis.fetch,
+    followRedirects = false,
+  }: { fetch?: FetchLike; followRedirects?: boolean } = {},
 ): Promise<DidDocument> {
-  const res = await fetch(url, { mode: "cors" })
+  const res = await fetch(url, {
+    mode: "cors",
+    redirect: followRedirects ? "follow" : "error",
+  })
 
   if (!res.ok) {
     throw new Error(
@@ -141,6 +158,7 @@ export function getResolver({
   docPath = DEFAULT_DOC_PATH,
   fetch = globalThis.fetch,
   allowedHttpHosts = DEFAULT_ALLOWED_HTTP_HOSTS,
+  followRedirects = false,
 }: DidWebResolverOptions = {}): { web: DIDResolver } {
   async function resolve(
     did: string,
@@ -155,7 +173,10 @@ export function getResolver({
     let didDocument: DIDDocument | null = null
 
     try {
-      didDocument = await fetchDidDocumentAtUrl(url, { fetch })
+      didDocument = await fetchDidDocumentAtUrl(url, {
+        fetch,
+        followRedirects,
+      })
 
       if (!isDidDocumentForDid(didDocument, did)) {
         throw new Error("DID document id does not match requested did")

--- a/packages/did/src/did-resolvers/web-did-resolver.ts
+++ b/packages/did/src/did-resolvers/web-did-resolver.ts
@@ -75,8 +75,21 @@ async function fetchDidDocumentAtUrl(
 ): Promise<DidDocument> {
   const res = await fetch(url, {
     mode: "cors",
-    redirect: followRedirects ? "follow" : "error",
+    redirect: followRedirects ? "follow" : "manual",
   })
+
+  // With `redirect: "manual"` a redirect resolves instead of throwing, so we
+  // can report it precisely. Node exposes the 3xx status and Location header;
+  // browsers return an opaque redirect (type "opaqueredirect", status 0).
+  if (
+    !followRedirects &&
+    (res.type === "opaqueredirect" || (res.status >= 300 && res.status < 400))
+  ) {
+    const location = res.headers.get("location")
+    throw new Error(
+      `DID resolution refused a redirect${location ? ` to ${location}` : ""}`,
+    )
+  }
 
   if (!res.ok) {
     throw new Error(

--- a/packages/did/src/did-resolvers/web-did-resolver.ts
+++ b/packages/did/src/did-resolvers/web-did-resolver.ts
@@ -52,6 +52,8 @@ export interface DidWebResolverOptions {
    * would have rejected. did:web documents are served directly at a
    * well-known path, so redirects are refused by default.
    *
+   * The policy is applied via `init.redirect` on the request. A custom
+   * `fetch` must honour `init.redirect` for it to take effect.
    * @default false
    */
   followRedirects?: boolean
@@ -94,9 +96,7 @@ async function fetchDidDocumentAtUrl(
     ...(timeout !== undefined ? { signal: AbortSignal.timeout(timeout) } : {}),
   })
 
-  // With `redirect: "manual"` a redirect resolves instead of throwing, so we
-  // can report it precisely. Node exposes the 3xx status and Location header;
-  // browsers return an opaque redirect (type "opaqueredirect", status 0).
+  // browsers surface manual redirects as an opaque response with status 0
   if (
     !followRedirects &&
     (res.type === "opaqueredirect" || (res.status >= 300 && res.status < 400))

--- a/packages/did/src/did-resolvers/web-did-resolver.ts
+++ b/packages/did/src/did-resolvers/web-did-resolver.ts
@@ -86,8 +86,9 @@ async function fetchDidDocumentAtUrl(
     (res.type === "opaqueredirect" || (res.status >= 300 && res.status < 400))
   ) {
     const location = res.headers.get("location")
+    const target = location ? ` to ${location}` : ""
     throw new Error(
-      `DID resolution refused a redirect${location ? ` to ${location}` : ""}`,
+      `DID resolution refused a redirect${target}. Set followRedirects: true to allow redirects.`,
     )
   }
 


### PR DESCRIPTION
## What

`getResolver` for `did:web` now sends `redirect: "error"` when fetching the DID document. A new `followRedirects?: boolean` option (default `false`) restores the previous behavior.

## Why

`allowedHttpHosts` is applied to the URL built from the DID:

```ts
const url = isHttpAllowed(path, allowedHttpHosts)
  ? `http://${path}`
  : `https://${path}`
```

The fetch that follows it used the platform default, which follows redirects. So the allowlist only governs the first hop: a `did:web` resolved over `https` can answer `302 Location: http://…`, and the resolver follows it to a scheme and host the check was there to reject.

```mermaid
flowchart LR
  D["did:web:issuer.example"] --> C{"allowedHttpHosts<br/>allows http for this host?"}
  C -- no --> U["fetch https://issuer.example/.well-known/did.json"]
  U --> H{"host answers 302<br/>Location: http://internal/…"}
  H -->|before: redirect followed| BAD["request lands on the scheme<br/>and host the check rejected"]
  H -->|after: redirect error| OK["resolution fails as notFound"]

  classDef bad stroke-dasharray: 4 3
  class BAD bad
```

Because the redirect target is chosen by the DID's own host, this also makes resolution an outbound request an untrusted party controls. That matters for anything that resolves a DID *before* verifying a signature, which is the normal order: you need the document to check the signature. A server verifying an ACK-ID proof from an arbitrary issuer will fetch whatever that issuer's host points it at.

did:web documents are served directly at `/.well-known/did.json` (or the configured `docPath`), so refusing redirects costs legitimate resolution nothing. Deployments that genuinely sit behind a redirect can opt in.

## How

- `DidWebResolverOptions` gains `followRedirects?: boolean`, documented with the reason, defaulting to `false`.
- `fetchDidDocumentAtUrl` passes `redirect: followRedirects ? "follow" : "error"` alongside the existing `mode: "cors"`.
- Existing tests that assert the fetch options were updated to include the new field; two tests cover the default (refuses, resolves to `notFound`) and the opt-in (`redirect: "follow"`).

## Test plan

```sh
pnpm build
pnpm --filter @agentcommercekit/did test   # 72 passed
```

Found while building an ACK-ID identity-gated x402 demo, where a seller resolves buyer DIDs it has never seen before.

Implemented and tested by gpt 5.6-sol and fable 5, reviewed by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `followRedirects: true` support for `did:web` and `did:jwks` resolution.
  * Redirects are now blocked by default for safer resolution.
  * Blocked redirects report the destination when available; otherwise, resolution returns a clear not-found or resolution error.
  * Enabling redirect following preserves existing successful resolution behavior.

* **Documentation**
  * Documented redirect-handling behavior and the `followRedirects` option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
