### PR TITLE
test(vc): add tests for the isVerifiable proof guard

### DIFF
--- a/packages/vc/src/verification/is-verifiable.test.ts
+++ b/packages/vc/src/verification/is-verifiable.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+
+import type { W3CCredential } from "../types"
+import { isVerifiable } from "./is-verifiable"
+
+// A minimal valid W3C credential, without a proof
+const baseCredential: W3CCredential = {
+  "@context": ["https://www.w3.org/2018/credentials/v1"],
+  type: ["VerifiableCredential"],
+  issuer: { id: "did:web:issuer.example.com" },
+  issuanceDate: "2025-01-01T00:00:00.000Z",
+  credentialSubject: { id: "did:web:subject.example.com" },
+}
+
+describe("isVerifiable", () => {
+  it("returns true when the credential carries a typed proof", () => {
+    const credential = { ...baseCredential, proof: { type: "JwtProof2020" } }
+    expect(isVerifiable(credential)).toBe(true)
+  })
+
+  it("returns true when the proof carries additional fields", () => {
+    const credential = {
+      ...baseCredential,
+      proof: { type: "JwtProof2020", jwt: "header.payload.signature" },
+    }
+    expect(isVerifiable(credential)).toBe(true)
+  })
+
+  it("returns false when no proof is present", () => {
+    expect(isVerifiable(baseCredential)).toBe(false)
+  })
+
+  it("returns false when proof is null", () => {
+    const credential = { ...baseCredential, proof: null }
+    expect(isVerifiable(credential)).toBe(false)
+  })
+
+  it("returns false when proof is present but undefined", () => {
+    const credential = { ...baseCredential, proof: undefined }
+    expect(isVerifiable(credential)).toBe(false)
+  })
+
+  it("returns false when proof is not an object", () => {
+    const credential = { ...baseCredential, proof: "JwtProof2020" }
+    expect(isVerifiable(credential)).toBe(false)
+  })
+
+  it("returns false when proof is an empty object", () => {
+    const credential = { ...baseCredential, proof: {} }
+    expect(isVerifiable(credential)).toBe(false)
+  })
+
+  it("returns false when proof has no type", () => {
+    const credential = {
+      ...baseCredential,
+      proof: { jwt: "header.payload.signature" },
+    }
+    expect(isVerifiable(credential)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

`isVerifiable` (`packages/vc/src/verification/is-verifiable.ts`) was the only helper on the verification path in `@agentcommercekit/vc` without a co-located test. It guards both `verify-parsed-credential` and `is-revoked`, so pinning down its proof shape contract is worthwhile.

This adds a unit test suite that covers each branch of the shape check:

- returns `true` for a proof object carrying a `type` (with and without extra fields)
- returns `false` when the proof is missing, `null`, `undefined`, or not an object
- returns `false` when the proof is an empty object or has no `type`

Tests only — no source changes.

## Testing

- `pnpm --filter @agentcommercekit/vc test` — the vc suite passes, including the 8 new cases
- `oxlint` and `oxfmt --check` are clean for the new file

## AI usage disclosure

Per `AI_POLICY.md`: these tests were written with AI assistance (Claude Code). I reviewed every case and understand the behavior each one verifies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for credential verifiability checks.
  * Verified handling of valid typed proofs and invalid, missing, empty, or improperly formatted proofs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->