### PR TITLE
fix: validate decimals and fail closed on unparseable expirationDate

### DIFF
--- a/packages/ack-pay/src/payment-request.test.ts
+++ b/packages/ack-pay/src/payment-request.test.ts
@@ -40,4 +40,17 @@ describe("isPaymentRequest", () => {
   it("returns false if given a non-object", () => {
     expect(isPaymentRequest(1)).toBe(false)
   })
+
+  it("returns false when decimals is negative", () => {
+    // decimals uses minValue(0) — a validation that rejects negative values.
+    // The previous toMinValue(0) silently clamped -6 to 0 instead of rejecting it.
+    expect(
+      isPaymentRequest({
+        ...validPaymentRequest,
+        paymentOptions: [
+          { ...validPaymentRequest.paymentOptions[0], decimals: -6 },
+        ],
+      }),
+    ).toBe(false)
+  })
 })

--- a/packages/ack-pay/src/schemas/valibot.ts
+++ b/packages/ack-pay/src/schemas/valibot.ts
@@ -7,7 +7,7 @@ const urlOrDidUri = v.union([v.pipe(v.string(), v.url()), didUriSchema])
 export const paymentOptionSchema = v.object({
   id: v.string(),
   amount: v.union([v.pipe(v.number(), v.integer(), v.gtValue(0)), v.string()]),
-  decimals: v.pipe(v.number(), v.integer(), v.toMinValue(0)),
+  decimals: v.pipe(v.number(), v.integer(), v.minValue(0)),
   currency: v.string(),
   recipient: v.string(),
   network: v.optional(v.string()),

--- a/packages/vc/src/verification/is-expired.test.ts
+++ b/packages/vc/src/verification/is-expired.test.ts
@@ -47,9 +47,16 @@ describe("isExpired", () => {
     expect(isExpired(credential)).toBe(false)
   })
 
-  it("handles invalid date strings gracefully", () => {
+  it("returns true for an unparseable expiration date (fail-closed)", () => {
     const credential = buildCredential("invalid-date")
+    // An unparseable date must not silently pass as not expired; failing
+    // closed is safer than failing open for a security-critical check.
+    expect(isExpired(credential)).toBe(true)
+  })
 
-    expect(isExpired(credential)).toBe(false)
+  it("returns true for an empty-string expiration date (fail-closed)", () => {
+    const credential = buildCredential("")
+    // Empty string is present but unparseable — fail closed.
+    expect(isExpired(credential)).toBe(true)
   })
 })

--- a/packages/vc/src/verification/is-expired.ts
+++ b/packages/vc/src/verification/is-expired.ts
@@ -7,15 +7,18 @@ import type { W3CCredential } from "../types"
  * @returns `true` if the credential is expired, `false` otherwise
  */
 export function isExpired(credential: W3CCredential): boolean {
-  if (!credential.expirationDate) {
+  if (credential.expirationDate === undefined) {
     return false
   }
 
   const expirationDate = new Date(credential.expirationDate)
 
   if (isNaN(expirationDate.getTime())) {
-    // Expiration date is invalid, so we consider the credential not expired
-    return false
+    // Expiration date is present but unparseable — fail closed and treat as
+    // expired. Returning false (not expired) would allow a credential with a
+    // garbage date to pass all downstream checks, which is the wrong default
+    // for a security-critical guard.
+    return true
   }
 
   return expirationDate < new Date()


### PR DESCRIPTION
Closes #147
Closes #148

## Changes

### `packages/ack-pay/src/schemas/valibot.ts`
Replace `v.toMinValue(0)` with `v.minValue(0)` for the `decimals` field.
`toMinValue` is a *transformation* that silently clamps negative values to 0;
`minValue` is a *validation* that rejects them with an error. A `decimals`
value of -3 should never silently become 0.

### `packages/vc/src/verification/is-expired.ts`
Return `true` (expired) instead of `false` when `expirationDate` is present
but unparseable. Returning `false` allows a credential with a garbage date to
pass all downstream verification checks the wrong default for a
security-critical guard. Failing closed is safer here.

---

> AI disclosure (per AI_POLICY.md): This fix was developed with Claude AI assistance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Payment option decimal values are now correctly rejected when below zero.
  * Credentials with invalid or empty expiration dates are now treated as expired, improving verification accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->