### PR TITLE
fix(caip): reject CAIP-2/CAIP-10 IDs with extra colon-delimited segments

### DIFF
--- a/packages/caip/src/caips/caip-10.test.ts
+++ b/packages/caip/src/caips/caip-10.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { createCaip10AccountId } from "./index"
+import { caip10Parts, createCaip10AccountId } from "./index"
 
 describe("createCaip10AccountId", () => {
   it("creates a caip 10 account ID for EVM address", () => {
@@ -35,5 +35,44 @@ describe("createCaip10AccountId", () => {
     expect(() => createCaip10AccountId("eip155:1", "")).toThrow(
       "Invalid CAIP-10 account address",
     )
+  })
+})
+
+describe("caip10Parts", () => {
+  it("parses a valid EVM CAIP-10 account ID", () => {
+    const result = caip10Parts(
+      "eip155:1:0x1234567890123456789012345678901234567890",
+    )
+    expect(result).toEqual({
+      namespace: "eip155",
+      reference: "1",
+      accountId: "0x1234567890123456789012345678901234567890",
+    })
+  })
+
+  it("throws for an empty string", () => {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- intentionally passing invalid input to exercise runtime validation
+    expect(() => caip10Parts("" as never)).toThrow(
+      "Invalid CAIP-10 account ID",
+    )
+  })
+
+  it("throws when the account address is missing", () => {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- intentionally passing invalid input to exercise runtime validation
+    expect(() => caip10Parts("eip155:1" as never)).toThrow(
+      "Invalid CAIP-10 account ID",
+    )
+  })
+
+  it("throws for an account ID with an extra colon-delimited segment", () => {
+    // Per the CAIP-10 spec, the account_address component cannot contain a
+    // colon (caip10AccountAddressPattern is `[-.%a-zA-Z0-9]{1,128}`), so a
+    // fourth colon-delimited segment makes the whole string invalid. A naive
+    // `split(":")` + destructure silently drops the extra segment instead of
+    // rejecting the malformed input.
+    expect(() =>
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- intentionally passing invalid input to exercise runtime validation
+      caip10Parts("eip155:1:0xabc:evil" as never),
+    ).toThrow("Invalid CAIP-10 account ID")
   })
 })

--- a/packages/caip/src/caips/caip-10.ts
+++ b/packages/caip/src/caips/caip-10.ts
@@ -48,8 +48,9 @@ export function createCaip10AccountId(
 }
 
 export function caip10Parts(caip: Caip10AccountId): Caip10AccountIdParts {
-  const [namespace, reference, accountId] = caip.split(":")
-  if (!namespace || !reference || !accountId) {
+  const parts = caip.split(":")
+  const [namespace, reference, accountId] = parts
+  if (!namespace || !reference || !accountId || parts.length !== 3) {
     throw new Error("Invalid CAIP-10 account ID")
   }
   return { namespace, reference, accountId }

--- a/packages/caip/src/caips/caip-2.test.ts
+++ b/packages/caip/src/caips/caip-2.test.ts
@@ -41,6 +41,17 @@ describe("caip2Parts", () => {
       "Invalid CAIP-2 chain ID",
     )
   })
+
+  it("throws for a chain ID with an extra colon-delimited segment", () => {
+    // Per the CAIP-2 spec, the reference component cannot contain a colon
+    // (caip2ReferencePattern is `[-_a-zA-Z0-9]{1,32}`), so a third
+    // colon-delimited segment makes the whole string invalid. A naive
+    // `split(":")` + destructure silently drops the extra segment instead
+    // of rejecting the malformed input.
+    expect(() =>
+      caip2Parts("eip155:1:evil" as `${string}:${string}`),
+    ).toThrow("Invalid CAIP-2 chain ID")
+  })
 })
 
 describe("caip2ChainIdRegex", () => {

--- a/packages/caip/src/caips/caip-2.ts
+++ b/packages/caip/src/caips/caip-2.ts
@@ -38,9 +38,10 @@ export const caip2ChainIds = {
 } as const
 
 export function caip2Parts(caip: Caip2ChainId): Caip2ChainIdParts {
-  const [namespace, reference] = caip.split(":")
+  const parts = caip.split(":")
+  const [namespace, reference] = parts
 
-  if (!namespace || !reference) {
+  if (!namespace || !reference || parts.length !== 2) {
     throw new Error("Invalid CAIP-2 chain ID")
   }
 


### PR DESCRIPTION
## Bug

`caip2Parts` and `caip10Parts` parse their input with `caip.split(":")` and
destructure the expected number of parts, but never check whether there
were *more* parts than expected. A string like `"eip155:1:evil"` is invalid
per the CAIP-2 spec (the reference component `[-_a-zA-Z0-9]{1,32}` cannot
contain a colon), but `caip2Parts` currently accepts it, silently dropping
the "evil" segment and returning `{ namespace: "eip155", reference: "1" }`
instead of throwing. Same issue in `caip10Parts` with a 4th segment.

This mirrors the exact bug class fixed in `createCaip10AccountId` in #67 —
that fix validates with `caip2ChainIdRegex`/`caip10AccountAddressRegex`
before constructing an ID, but the "Parts" parsing functions going the
other direction (string → components) were never covered, and have no
tests for malformed multi-segment input.

Both functions are exported from `@agentcommercekit/caip`'s public API, so
downstream consumers calling them directly on untrusted input (e.g. a CAIP
string embedded in a DID or credential) would get a silently-truncated
parse instead of a validation error.

Current call sites in this repo (`packages/did/src/methods/did-pkh.ts`)
happen to already validate upstream with `isCaip10AccountId` /
`createCaip10AccountId`, so this isn't exploitable through them today —
this is a defense-in-depth / spec-conformance fix for the exported function
itself.

## Fix

Both functions now also check that `split(":")` produced exactly the
expected number of segments, throwing the existing error message otherwise.

## Testing

Added tests reproducing the bug (confirmed they fail on unpatched `main`:
"expected [Function] to throw an error"), passing with the fix. Also added
missing basic coverage for `caip10Parts`, which had none before.

- `packages/caip`: 86/86 passing (was 27/27 before this PR's added tests)
- `packages/did` (the package that actually calls `caip10Parts`): 74/74
  passing, no regressions
- `oxlint` and `tsc --noEmit`: clean

## AI usage disclosure

Per AI_POLICY.md: this fix was found and implemented with Claude (Anthropic).
I asked it to review the caip package for validation gaps given the recent
#67 fix in the same area; it identified the split-based truncation issue,
wrote the failing tests, confirmed them against unpatched `main`, then
applied and verified the fix and ran the affected package + downstream
consumer test suites. I've reviewed the diff and understand the bug and
the fix — happy to answer any questions about it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for chain and account identifiers.
  * Invalid identifiers containing extra colon-separated segments are now rejected.
  * Existing validation for missing namespaces or references remains intact.

* **Tests**
  * Added coverage for valid, incomplete, empty, and malformed identifier inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->