### PR TITLE
fix(ack-pay): reject a negative decimals instead of clamping it

### DIFF
--- a/.changeset/payment-option-decimals-validation.md
+++ b/.changeset/payment-option-decimals-validation.md
@@ -1,0 +1,14 @@
+---
+"@agentcommercekit/ack-pay": minor
+---
+
+`paymentOptionSchema` now rejects a negative `decimals` instead of normalizing
+it. The valibot schema used `toMinValue(0)`, which is a transformation that
+clamps rather than a validation that rejects, so `decimals: -2` parsed
+successfully as `decimals: 0`.
+
+`decimals` scales `amount`, so clamping turned an invalid payment option into a
+valid one asking for a different sum, and it did so on the verification path as
+well: `verifyPaymentRequestToken` parses token payloads with this schema. The
+zod schema already rejected the same input via `nonnegative()`, so the two
+validators disagreed about which payment requests are well-formed.

--- a/packages/ack-pay/src/payment-request.test.ts
+++ b/packages/ack-pay/src/payment-request.test.ts
@@ -29,6 +29,19 @@ describe("isPaymentRequest", () => {
     ).toBe(false)
   })
 
+  // `decimals` scales `amount`, so a negative value has to be rejected rather
+  // than normalized: reading it as 0 silently changes what the request asks for.
+  it("returns false if decimals is negative", () => {
+    expect(
+      isPaymentRequest({
+        ...validPaymentRequest,
+        paymentOptions: [
+          { ...validPaymentRequest.paymentOptions[0], decimals: -2 },
+        ],
+      }),
+    ).toBe(false)
+  })
+
   it("returns false if given null", () => {
     expect(isPaymentRequest(null)).toBe(false)
   })

--- a/packages/ack-pay/src/schemas/valibot.ts
+++ b/packages/ack-pay/src/schemas/valibot.ts
@@ -7,7 +7,7 @@ const urlOrDidUri = v.union([v.pipe(v.string(), v.url()), didUriSchema])
 export const paymentOptionSchema = v.object({
   id: v.string(),
   amount: v.union([v.pipe(v.number(), v.integer(), v.gtValue(0)), v.string()]),
-  decimals: v.pipe(v.number(), v.integer(), v.toMinValue(0)),
+  decimals: v.pipe(v.number(), v.integer(), v.minValue(0)),
   currency: v.string(),
   recipient: v.string(),
   network: v.optional(v.string()),


### PR DESCRIPTION
## Problem

`paymentOptionSchema` validates `decimals` with valibot's `toMinValue(0)`. That is a transformation that clamps, not a validation that rejects, so a negative value parses successfully as `0`:

```
input decimals : -2
valibot output : 0
zod accepts?   : false
zod error      : Too small: expected number to be >=0
```

`decimals` scales `amount`, so this does not just normalize a stray value — it turns an invalid payment option into a valid one asking for a different sum, and it does so silently. It applies on the verification path too, since `verifyPaymentRequestToken` parses token payloads with this schema.

The zod schema next to it already uses `z.number().int().nonnegative()`, so the two validators disagreed about which payment requests are well-formed. Every other bound in the repo uses the validating form (`v.minValue`), which is what makes this look like a slip rather than a decision.

## Fix

`v.toMinValue(0)` becomes `v.minValue(0)`, plus a test that a negative `decimals` is rejected. After the change both validators reject the same input and valid values still parse.

This is a breaking change in the sense that input previously accepted now fails, which is the point: accepting it was the bug. Nothing in the repo passes a negative `decimals`, so no existing caller breaks.

## Testing

`pnpm check` passes.

## AI usage disclosure

Per [AI_POLICY.md](https://github.com/agentcommercekit/ack/blob/main/AI_POLICY.md): this change was AI-assisted using Cursor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payment validation now rejects negative decimal values instead of silently converting them to zero.
  * Payment request verification preserves the intended payment amounts and aligns validation behavior across supported schemas.

* **Tests**
  * Added coverage confirming that payment requests with negative decimal values are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->