### PR TITLE
fix(ack-pay): valibot decimals validator rejects negative values instead of clamping

### DIFF
--- a/.changeset/decimals-clamp-fix.md
+++ b/.changeset/decimals-clamp-fix.md
@@ -1,0 +1,16 @@
+---
+"@agentcommercekit/ack-pay": patch
+---
+
+Fix `paymentOptionSchema`'s `decimals` field silently clamping negative
+values instead of rejecting them (valibot schema)
+
+The valibot version of `paymentOptionSchema` used `v.toMinValue(0)` on the
+`decimals` field, which is a **transform** that silently clamps a negative
+number up to `0` rather than a validator that rejects it. This diverged from
+the zod version of the same schema (`z.number().int().nonnegative()`), which
+correctly rejects negative values.
+
+Switched to `v.minValue(0)`, valibot's validating counterpart, so a payment
+option with a malformed negative `decimals` value is now rejected by both
+schema implementations instead of being silently "fixed" by the valibot one.

--- a/packages/ack-pay/src/schemas/decimals.test.ts
+++ b/packages/ack-pay/src/schemas/decimals.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+import * as v from "valibot"
+
+import { paymentOptionSchema as valibotPaymentOptionSchema } from "./valibot"
+import { paymentOptionSchema as zodPaymentOptionSchema } from "./zod"
+
+function baseOption(decimals: number) {
+  return {
+    id: "opt-1",
+    amount: 100,
+    decimals,
+    currency: "USD",
+    recipient: "did:example:recipient",
+  }
+}
+
+describe("paymentOptionSchema decimals", () => {
+  it("valibot rejects a negative decimals value instead of clamping it to 0", () => {
+    const result = v.safeParse(valibotPaymentOptionSchema, baseOption(-5))
+
+    expect(result.success).toBe(false)
+  })
+
+  it("zod rejects a negative decimals value", () => {
+    const result = zodPaymentOptionSchema.safeParse(baseOption(-5))
+
+    expect(result.success).toBe(false)
+  })
+
+  it("valibot and zod agree: zero and positive decimals are valid", () => {
+    for (const decimals of [0, 2, 18]) {
+      expect(
+        v.safeParse(valibotPaymentOptionSchema, baseOption(decimals)).success,
+      ).toBe(true)
+      expect(
+        zodPaymentOptionSchema.safeParse(baseOption(decimals)).success,
+      ).toBe(true)
+    }
+  })
+})

--- a/packages/ack-pay/src/schemas/decimals.test.ts
+++ b/packages/ack-pay/src/schemas/decimals.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest"
 import * as v from "valibot"
+import { describe, expect, it } from "vitest"
 
 import { paymentOptionSchema as valibotPaymentOptionSchema } from "./valibot"
 import { paymentOptionSchema as zodPaymentOptionSchema } from "./zod"

--- a/packages/ack-pay/src/schemas/valibot.ts
+++ b/packages/ack-pay/src/schemas/valibot.ts
@@ -7,7 +7,7 @@ const urlOrDidUri = v.union([v.pipe(v.string(), v.url()), didUriSchema])
 export const paymentOptionSchema = v.object({
   id: v.string(),
   amount: v.union([v.pipe(v.number(), v.integer(), v.gtValue(0)), v.string()]),
-  decimals: v.pipe(v.number(), v.integer(), v.toMinValue(0)),
+  decimals: v.pipe(v.number(), v.integer(), v.minValue(0)),
   currency: v.string(),
   recipient: v.string(),
   network: v.optional(v.string()),


### PR DESCRIPTION
Fixes #147

The valibot version of `paymentOptionSchema` used `v.toMinValue(0)` on the `decimals` field — a **transform** that silently clamps a negative number up to `0`, rather than a validator that rejects it. This diverged from the zod version of the same schema (`z.number().int().nonnegative()`), which correctly rejects negative values.

**Fix:** switched to `v.minValue(0)`, valibot's validating counterpart, so a payment option with a malformed negative `decimals` value is rejected by both schema implementations instead of being silently "fixed" by the valibot one.

**Tests:** added a regression test asserting both schemas reject a negative `decimals` value and agree on valid (zero/positive) values.

**Changeset:** added (`@agentcommercekit/ack-pay`, patch).

Verified locally: `vitest run src/schemas/decimals.test.ts` (3/3 passing — confirmed it fails against the old `toMinValue` code and passes with the fix), `oxlint` and `oxfmt --check` clean.

---

**AI usage disclosure** (per AI_POLICY.md): this fix was developed with Claude (Anthropic) assistance — identifying the divergence between the valibot and zod schemas, writing the fix, writing the test, and verifying locally. I reviewed and understand the change: it's a one-word swap (`toMinValue` → `minValue`) that changes valibot's `decimals` validation from a silent clamp to a rejection, matching zod's existing behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Payment option decimal values now consistently reject negative numbers.
  * Zero and positive decimal values continue to be accepted across supported validation formats.

* **Tests**
  * Added coverage to verify consistent decimal validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->