### PR TITLE
docs(jwt): drop the incorrect alg curve-alias claim in createJwt

### DIFF
--- a/packages/jwt/src/create-jwt.ts
+++ b/packages/jwt/src/create-jwt.ts
@@ -25,9 +25,7 @@ export interface JwtHeader extends Omit<JWTHeader, "alg" | "typ"> {
  * @param payload - The payload to create the JWT from
  * @param options - The options to create the JWT from
  * @param header - Optional header overrides
- * @param header.alg - The algorithm to use for the JWT. Accepts `secp256k1` and
- *  `Ed25519` as aliases for `ES256K` and `EdDSA` respectively. Defaults to
- *  `ES256K`.
+ * @param header.alg - The algorithm to use for the JWT. Defaults to `ES256K`.
  * @returns The JWT
  */
 export async function createJwt(


### PR DESCRIPTION
## Summary

Updated per review: dropped the API-widening approach and reduced this to the one-line doc fix requested.

`createJwt`'s JSDoc claimed `alg` accepts `secp256k1`/`Ed25519` as aliases, but the code never resolved them and every caller passes a `JwtAlgorithm` directly. This removes the stale alias sentence so the docstring matches the code — no code, type, or test changes.

## AI usage disclosure

Per `AI_POLICY.md`: written with AI assistance (Claude Code). I reviewed the change and understand it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the documentation for JWT algorithm configuration.
  * Clarified that the algorithm defaults to `ES256K`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->