### PR TITLE
fix(ack-pay): enforce payment request expiresAt

### DIFF
--- a/.changeset/ack-pay-expires-at-verification.md
+++ b/.changeset/ack-pay-expires-at-verification.md
@@ -1,0 +1,5 @@
+---
+"@agentcommercekit/ack-pay": patch
+---
+
+Reject payment requests whose `expiresAt` timestamp has passed when expiry verification is enabled.

--- a/packages/ack-pay/src/verify-payment-receipt.test.ts
+++ b/packages/ack-pay/src/verify-payment-receipt.test.ts
@@ -28,6 +28,9 @@ import type { PaymentRequestInit } from "./payment-request"
 import { isPaymentReceiptCredential } from "./receipt-claim-verifier"
 import { verifyPaymentReceipt } from "./verify-payment-receipt"
 
+/** A clearly past ISO 8601 timestamp, fixed for determinism. */
+const PAST_EXPIRES_AT = "2000-01-01T00:00:00.000Z"
+
 describe("verifyPaymentReceipt()", () => {
   let resolver: Resolvable
   let unsignedReceipt: W3CCredential
@@ -92,6 +95,57 @@ describe("verifyPaymentReceipt()", () => {
     const result = await verifyPaymentReceipt(signedReceiptJwt, { resolver })
     expect(result.receipt).toBeDefined()
     expect(result.paymentRequestToken).toBeDefined()
+    expect(result.paymentRequest).toBeDefined()
+  })
+
+  it("validates a receipt over an expired payment request", async () => {
+    const expiredRequestIssuerKeypair = await generateKeypair("secp256k1")
+    const expiredRequestIssuerDid = createDidKeyUri(expiredRequestIssuerKeypair)
+
+    const expiredRequest = await createSignedPaymentRequest(
+      {
+        id: "test-expired-request-id",
+        paymentOptions: [
+          {
+            id: "test-payment-option-id",
+            amount: 100,
+            decimals: 2,
+            currency: "USD",
+            network: "eip155:84532",
+            recipient: "0x592D4858DE40BC81A77E5B373238B70D7C79D3C79",
+          },
+        ],
+        expiresAt: PAST_EXPIRES_AT,
+      },
+      {
+        issuer: expiredRequestIssuerDid,
+        signer: createJwtSigner(expiredRequestIssuerKeypair),
+        algorithm: curveToJwtAlgorithm(expiredRequestIssuerKeypair.curve),
+      },
+    )
+
+    const unsignedExpiredReceipt = createPaymentReceipt({
+      paymentRequestToken: expiredRequest.paymentRequestToken,
+      paymentOptionId: expiredRequest.paymentRequest.paymentOptions[0].id,
+      issuer: receiptIssuerDid,
+      payerDid: createDidPkhUri(
+        "eip155:84532",
+        "0x7B3D8F2E1C9A4B5D6E7F8A9B0C1D2E3F4A5B6C",
+      ),
+    })
+    const signedExpiredReceiptJwt = await signCredential(
+      unsignedExpiredReceipt,
+      {
+        did: receiptIssuerDid,
+        signer: createJwtSigner(receiptIssuerKeypair),
+      },
+    )
+
+    const result = await verifyPaymentReceipt(signedExpiredReceiptJwt, {
+      resolver,
+    })
+    expect(result.receipt).toBeDefined()
+    expect(result.paymentRequestToken).toBe(expiredRequest.paymentRequestToken)
     expect(result.paymentRequest).toBeDefined()
   })
 

--- a/packages/ack-pay/src/verify-payment-request-token.test.ts
+++ b/packages/ack-pay/src/verify-payment-request-token.test.ts
@@ -19,6 +19,11 @@ import { InvalidPaymentRequestTokenError } from "./errors"
 import type { PaymentRequestInit } from "./payment-request"
 import { verifyPaymentRequestToken } from "./verify-payment-request-token"
 
+/** A clearly past ISO 8601 timestamp, fixed for determinism. */
+const PAST_EXPIRES_AT = "2000-01-01T00:00:00.000Z"
+/** A clearly future ISO 8601 timestamp, fixed for determinism. */
+const FUTURE_EXPIRES_AT = "2999-12-31T23:59:59.000Z"
+
 /**
  * Removes undefined values from the payment request
  */
@@ -205,5 +210,67 @@ describe("verifyPaymentRequestToken", () => {
       "Payment Request token is not a valid PaymentRequest",
     )
     expect(error.cause).toBeUndefined()
+  })
+
+  it("throws for a payment request whose expiresAt has passed", async () => {
+    const body = await createSignedPaymentRequest(
+      { ...paymentRequest, expiresAt: PAST_EXPIRES_AT },
+      {
+        issuer: issuerDid,
+        signer,
+        algorithm: curveToJwtAlgorithm(keypair.curve),
+      },
+    )
+
+    const resolver = getDidResolver()
+    resolver.addToCache(issuerDid, issuerDidDocument)
+
+    const error = await verifyPaymentRequestToken(body.paymentRequestToken, {
+      resolver,
+    }).catch((e) => e)
+
+    expect(error).toBeInstanceOf(InvalidPaymentRequestTokenError)
+    expect(error.message).toBe("Payment request has expired")
+  })
+
+  it("accepts a payment request whose expiresAt is in the future", async () => {
+    const body = await createSignedPaymentRequest(
+      { ...paymentRequest, expiresAt: FUTURE_EXPIRES_AT },
+      {
+        issuer: issuerDid,
+        signer,
+        algorithm: curveToJwtAlgorithm(keypair.curve),
+      },
+    )
+
+    const resolver = getDidResolver()
+    resolver.addToCache(issuerDid, issuerDidDocument)
+
+    const result = await verifyPaymentRequestToken(body.paymentRequestToken, {
+      resolver,
+    })
+
+    expect(result.paymentRequest.id).toBe(paymentRequest.id)
+  })
+
+  it("accepts an expired payment request when expiry verification is disabled", async () => {
+    const body = await createSignedPaymentRequest(
+      { ...paymentRequest, expiresAt: PAST_EXPIRES_AT },
+      {
+        issuer: issuerDid,
+        signer,
+        algorithm: curveToJwtAlgorithm(keypair.curve),
+      },
+    )
+
+    const resolver = getDidResolver()
+    resolver.addToCache(issuerDid, issuerDidDocument)
+
+    const result = await verifyPaymentRequestToken(body.paymentRequestToken, {
+      resolver,
+      verifyExpiry: false,
+    })
+
+    expect(result.paymentRequest.id).toBe(paymentRequest.id)
   })
 })

--- a/packages/ack-pay/src/verify-payment-request-token.ts
+++ b/packages/ack-pay/src/verify-payment-request-token.ts
@@ -12,7 +12,7 @@ interface ValidatePaymentRequestTokenOptions {
    */
   resolver?: Resolvable
   /**
-   * Whether to verify the expiry of the payment request token
+   * Whether to verify JWT `exp` and PaymentRequest `expiresAt`
    */
   verifyExpiry?: boolean
   /**
@@ -56,6 +56,15 @@ export async function verifyPaymentRequestToken(
     throw new InvalidPaymentRequestTokenError(
       "Payment Request token is not a valid PaymentRequest",
     )
+  }
+
+  // `expiresAt` is a business-level expiry distinct from JWT `exp`.
+  if (
+    options.verifyExpiry !== false &&
+    output.expiresAt !== undefined &&
+    Date.parse(output.expiresAt) <= Date.now()
+  ) {
+    throw new InvalidPaymentRequestTokenError("Payment request has expired")
   }
 
   return {


### PR DESCRIPTION
`PaymentRequest.expiresAt` is documented as the point after which a payment request becomes invalid, but `verifyPaymentRequestToken` only enforced the standard JWT `exp` claim.

Payment requests created through ACK-Pay carry `expiresAt` in the JWT payload without an `exp` claim, so a validly signed request with a past `expiresAt` was still accepted by the default verification path.

**Fix:** after parsing the payment request, reject it when `expiresAt` has passed and expiry verification is enabled. `verifyExpiry: false` continues to skip expiry checks, preserving the existing receipt-verification behavior where receipts may outlive the payment request.

**Tests:** added regression coverage for past and future `expiresAt` values, `verifyExpiry: false`, and verifying a receipt over an expired payment request.

**Changeset:** added (`@agentcommercekit/ack-pay`, patch).

Related to #120, but non-overlapping: that PR validates and normalizes `expiresAt` values at the schema level; this change enforces the parsed timestamp during verification.

Verified locally: `@agentcommercekit/ack-pay` tests (38/38), package build, `oxlint`, `oxfmt --check`, and `git diff --check`.

---

**AI usage disclosure** (per AI_POLICY.md): this fix was developed with AI assistance (Codex - GPT 5.6 Sol).  I reviewed the final diff and understand the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added expiration validation for payment requests when expiry verification is enabled.
  - Expired payment requests are rejected, while future-dated requests are accepted.
  - Expiry checks can be disabled when needed.
  - Payment receipts referencing expired requests continue to validate successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->