### PR TITLE
fix(ack-pay): validate string payment amounts

### DIFF
--- a/.changeset/clean-amount-strings.md
+++ b/.changeset/clean-amount-strings.md
@@ -1,0 +1,5 @@
+---
+"@agentcommercekit/ack-pay": patch
+---
+
+Reject malformed, fractional, zero, and negative string payment amounts while preserving positive integer strings for values larger than JavaScript's safe integer range.

--- a/packages/ack-pay/src/schemas/payment-option.test.ts
+++ b/packages/ack-pay/src/schemas/payment-option.test.ts
@@ -1,0 +1,37 @@
+import * as v from "valibot"
+import { describe, expect, it } from "vitest"
+
+import { paymentOptionSchema as valibotPaymentOptionSchema } from "./valibot"
+import { paymentOptionSchema as zodPaymentOptionSchema } from "./zod"
+
+const paymentOption = {
+  id: "test-payment-option-id",
+  decimals: 2,
+  currency: "USD",
+  recipient: "did:example:recipient",
+}
+
+function acceptsAmount(amount: number | string) {
+  const value = { ...paymentOption, amount }
+
+  return {
+    valibot: v.safeParse(valibotPaymentOptionSchema, value).success,
+    zod: zodPaymentOptionSchema.safeParse(value).success,
+  }
+}
+
+describe("paymentOptionSchema amount", () => {
+  it.each([1, 100, "1", "100", "9007199254740993"])(
+    "accepts positive integer amount %s",
+    (amount) => {
+      expect(acceptsAmount(amount)).toEqual({ valibot: true, zod: true })
+    },
+  )
+
+  it.each([0, -1, 1.5, "", "0", "-1", "1.5", "abc"])(
+    "rejects invalid amount %s",
+    (amount) => {
+      expect(acceptsAmount(amount)).toEqual({ valibot: false, zod: false })
+    },
+  )
+})

--- a/packages/ack-pay/src/schemas/valibot.ts
+++ b/packages/ack-pay/src/schemas/valibot.ts
@@ -3,10 +3,14 @@ import { jwtStringSchema } from "@agentcommercekit/jwt/schemas/valibot"
 import * as v from "valibot"
 
 const urlOrDidUri = v.union([v.pipe(v.string(), v.url()), didUriSchema])
+const positiveIntegerString = v.pipe(v.string(), v.regex(/^[1-9]\d*$/))
 
 export const paymentOptionSchema = v.object({
   id: v.string(),
-  amount: v.union([v.pipe(v.number(), v.integer(), v.gtValue(0)), v.string()]),
+  amount: v.union([
+    v.pipe(v.number(), v.integer(), v.gtValue(0)),
+    positiveIntegerString,
+  ]),
   decimals: v.pipe(v.number(), v.integer(), v.toMinValue(0)),
   currency: v.string(),
   recipient: v.string(),

--- a/packages/ack-pay/src/schemas/zod.ts
+++ b/packages/ack-pay/src/schemas/zod.ts
@@ -3,10 +3,11 @@ import { jwtStringSchema } from "@agentcommercekit/jwt/schemas/zod"
 import * as z from "zod"
 
 const urlOrDidUri = z.union([z.url(), didUriSchema])
+const positiveIntegerString = z.string().regex(/^[1-9]\d*$/)
 
 export const paymentOptionSchema = z.object({
   id: z.string(),
-  amount: z.union([z.number().int().positive(), z.string()]),
+  amount: z.union([z.number().int().positive(), positiveIntegerString]),
   decimals: z.number().int().nonnegative(),
   currency: z.string(),
   recipient: z.string(),


### PR DESCRIPTION
## Summary

Tighten `paymentOptionSchema.amount` validation so string amounts follow the same positive-integer contract as numeric amounts.

Currently the numeric branch requires a positive integer, while the string branch accepts any string. This allows values such as `""`, `"0"`, `"-1"`, `"1.5"`, and `"abc"` through schema validation even though payment amounts are expressed as integers in the smallest currency unit.

## Changes

- validate string amounts as positive integer strings in both Valibot and Zod schemas
- keep string support for integers beyond JavaScript's safe integer range
- add shared regression coverage for accepted and rejected values across both schema implementations
- add an `@agentcommercekit/ack-pay` patch changeset

## Validation

The regression tests cover positive numeric/string integers and reject zero, negative, fractional, empty, and non-numeric values in both schema implementations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payment amounts now reject invalid values such as zero, negatives, fractions, empty strings, and nonnumeric text.
  * Large positive integer amounts provided as strings remain supported, including values beyond JavaScript’s safe integer range.

* **Tests**
  * Added coverage to verify consistent validation across supported schema implementations.

* **Chores**
  * Scheduled a patch release for the payment package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->