### PR TITLE
fix(keys): reject invalid private JWK fields

### DIFF
--- a/.changeset/harden-private-jwk-guard.md
+++ b/.changeset/harden-private-jwk-guard.md
@@ -1,0 +1,5 @@
+---
+"@agentcommercekit/keys": patch
+---
+
+Reject JWK objects with invalid private key fields in key type guards.

--- a/packages/keys/src/encoding/jwk.test.ts
+++ b/packages/keys/src/encoding/jwk.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest"
 
 import { bytesToBase64url, isBase64url } from "./base64"
 import {
+  isJwk,
   isPrivateKeyJwk,
   isPublicKeyJwk,
   isPublicKeyJwkEd25519,
@@ -172,6 +173,19 @@ describe("JWK encoding", () => {
         // missing d
       }
       expect(isPrivateKeyJwk(invalidJwk)).toBe(false)
+    })
+
+    test("rejects private key JWKs with invalid d values", () => {
+      const baseJwk = {
+        kty: "OKP" as const,
+        crv: "Ed25519" as const,
+        x: "base64x",
+      }
+
+      expect(isPrivateKeyJwk({ ...baseJwk, d: 1 })).toBe(false)
+      expect(isPrivateKeyJwk({ ...baseJwk, d: "" })).toBe(false)
+      expect(isJwk({ ...baseJwk, d: 1 })).toBe(false)
+      expect(isJwk({ ...baseJwk, d: "" })).toBe(false)
     })
   })
 

--- a/packages/keys/src/encoding/jwk.test.ts
+++ b/packages/keys/src/encoding/jwk.test.ts
@@ -181,11 +181,21 @@ describe("JWK encoding", () => {
         crv: "Ed25519" as const,
         x: "base64x",
       }
+      const secp256k1Jwk = {
+        kty: "EC" as const,
+        crv: "secp256k1" as const,
+        x: "base64x",
+        y: "base64y",
+      }
 
       expect(isPrivateKeyJwk({ ...baseJwk, d: 1 })).toBe(false)
       expect(isPrivateKeyJwk({ ...baseJwk, d: "" })).toBe(false)
       expect(isJwk({ ...baseJwk, d: 1 })).toBe(false)
       expect(isJwk({ ...baseJwk, d: "" })).toBe(false)
+      expect(isPrivateKeyJwk({ ...secp256k1Jwk, d: 1 })).toBe(false)
+      expect(isPrivateKeyJwk({ ...secp256k1Jwk, d: "" })).toBe(false)
+      expect(isJwk({ ...secp256k1Jwk, d: 1 })).toBe(false)
+      expect(isJwk({ ...secp256k1Jwk, d: "" })).toBe(false)
     })
   })
 

--- a/packages/keys/src/encoding/jwk.ts
+++ b/packages/keys/src/encoding/jwk.ts
@@ -6,6 +6,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
 }
 
+function hasValidPrivateKey(jwk: Record<string, unknown>): boolean {
+  return !("d" in jwk) || (typeof jwk.d === "string" && jwk.d.length > 0)
+}
+
 /**
  * JWK-encoding
  */
@@ -96,7 +100,7 @@ function isJwkSecp256(
     return false
   }
 
-  return true
+  return hasValidPrivateKey(jwk)
 }
 
 /**
@@ -142,7 +146,7 @@ export function isJwkEd25519(jwk: unknown): jwk is JwkEd25519 {
     return false
   }
 
-  return true
+  return hasValidPrivateKey(jwk)
 }
 
 export function isJwk(jwk: unknown): jwk is Jwk {
@@ -178,7 +182,7 @@ export function isPublicKeyJwkEd25519(
  * Check if an object is a valid private key JWK
  */
 export function isPrivateKeyJwk(jwk: unknown): jwk is PrivateKeyJwk {
-  return isJwk(jwk) && !!jwk.d
+  return isJwk(jwk) && "d" in jwk
 }
 
 export function isPrivateKeyJwkSecp256k1(

--- a/packages/keys/src/encoding/jwk.ts
+++ b/packages/keys/src/encoding/jwk.ts
@@ -6,7 +6,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
 }
 
-function hasValidPrivateKey(jwk: Record<string, unknown>): boolean {
+function hasValidPrivateKeyField(jwk: Record<string, unknown>): boolean {
   return !("d" in jwk) || (typeof jwk.d === "string" && jwk.d.length > 0)
 }
 
@@ -100,7 +100,7 @@ function isJwkSecp256(
     return false
   }
 
-  return hasValidPrivateKey(jwk)
+  return hasValidPrivateKeyField(jwk)
 }
 
 /**
@@ -146,7 +146,7 @@ export function isJwkEd25519(jwk: unknown): jwk is JwkEd25519 {
     return false
   }
 
-  return hasValidPrivateKey(jwk)
+  return hasValidPrivateKeyField(jwk)
 }
 
 export function isJwk(jwk: unknown): jwk is Jwk {


### PR DESCRIPTION
## Summary

- Require a present JWK private key field (`d`) to be a non-empty string
- Add regression coverage for invalid `d` values on Ed25519 and secp256k1 JWKs
- Add a patch changeset for `@agentcommercekit/keys`

## Why

The JWK guards distinguish public keys by the absence of `d` and private keys by its presence. This tightens that boundary so malformed private-key fields are not accepted by `isJwk` or `isPrivateKeyJwk`.

## Verification

- `pnpm --filter @agentcommercekit/keys test`
- `pnpm --filter @agentcommercekit/keys build`
- `node_modules\.bin\oxfmt.CMD --check packages/keys/src/encoding/jwk.ts packages/keys/src/encoding/jwk.test.ts .changeset/harden-private-jwk-guard.md`
- `git diff --check`

## AI usage disclosure

AI-assisted with ChatGPT/Codex for repository navigation, implementation, and tests. I reviewed and understand the final change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON Web Key validation to reject private keys with empty or non-string private-key values.
  * Corrected private-key detection for supported Ed25519 and secp256k1 keys.

* **Tests**
  * Added coverage for numeric and empty private-key fields across JWK validation checks.

* **Release**
  * Prepared a patch release for the keys package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->