### PR TITLE
fix(keys): accept a bare 0x prefix in isHexString

### DIFF
--- a/.changeset/is-hex-string-empty-body.md
+++ b/.changeset/is-hex-string-empty-body.md
@@ -1,0 +1,5 @@
+---
+"@agentcommercekit/keys": patch
+---
+
+`isHexString` now returns `true` for a bare `0x` prefix with an empty body, matching its documented behavior. The check required at least one hex digit after the prefix, so `isHexString("0x")` returned `false` even though the JSDoc example states it returns `true`. A bare empty string with no prefix (`""`) continues to return `false`.

--- a/packages/keys/src/encoding/hex.test.ts
+++ b/packages/keys/src/encoding/hex.test.ts
@@ -44,6 +44,14 @@ describe("isHexString", () => {
     expect(isHexString("1234567890abcdef")).toBe(true)
   })
 
+  test("returns true for a bare 0x prefix with an empty body", () => {
+    expect(isHexString("0x")).toBe(true)
+  })
+
+  test("returns false for an empty string with no prefix", () => {
+    expect(isHexString("")).toBe(false)
+  })
+
   test("returns false for invalid hex strings", () => {
     expect(isHexString("0x1234567890abcdefg")).toBe(false)
     expect(isHexString("not hex")).toBe(false)

--- a/packages/keys/src/encoding/hex.ts
+++ b/packages/keys/src/encoding/hex.ts
@@ -47,6 +47,14 @@ export function isHexString(value: unknown): value is string {
     return false
   }
 
-  const hexWithoutPrefix = value.startsWith("0x") ? value.slice(2) : value
+  const hasPrefix = value.startsWith("0x")
+  const hexWithoutPrefix = hasPrefix ? value.slice(2) : value
+
+  // A bare "0x" prefix has an empty body and is a valid (zero-length) hex
+  // string, as documented above. An empty string with no prefix is not.
+  if (hexWithoutPrefix.length === 0) {
+    return hasPrefix
+  }
+
   return /^[0-9A-Fa-f]+$/.test(hexWithoutPrefix)
 }


### PR DESCRIPTION
## Problem

The JSDoc for `isHexString` at `packages/keys/src/encoding/hex.ts:41` documents:

```ts
isHexString("0x") // true
```

The implementation returns `false`. It strips the `0x` prefix and tests the remainder against `/^[0-9A-Fa-f]+$/` — the `+` quantifier requires at least one character, so `"0x"` reduces to `""` and fails.

Documented behaviour the code doesn't implement.

## Fix

An explicit branch for the bare-prefix case, so `"0x"` matches the documented result.

`""` deliberately stays `false`. The JSDoc says nothing about a bare empty string, and widening the quantifier to `*` would have changed that too — an undocumented behaviour change riding along with a documented fix. The explicit branch keeps the diff to exactly what the doc promises.

`isHexString` has no internal callers (verified by grep), so blast radius is limited to external consumers relying on the documented contract.

## Tests

A case in `hex.test.ts` covering the bare prefix, plus one pinning `""` as `false` so the distinction is intentional rather than incidental. Verified failing-first: before the change the `"0x"` case fails.

`@agentcommercekit/keys` — 101 tests pass. Full `pnpm run check` green: build 8/8, lint 0 warnings 0 errors, format clean, 29/29 tasks.

## Changeset

`patch` for `@agentcommercekit/keys`, matching the bump used by comparable one-line fixes such as #116.

---

AI Disclosure: Written with Claude Code. It located the doc/runtime divergence and wrote the guard and tests; I reviewed the diff and can explain the change and its trade-offs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated hexadecimal string validation so `"0x"` is recognized as a valid zero-length hexadecimal value.
  * Empty unprefixed strings remain invalid.
  * Existing validation for non-empty hexadecimal values is unchanged.

* **Tests**
  * Added coverage for prefixed and unprefixed empty hexadecimal strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->