### PR TITLE
fix(did): reject `did:key:z` in isDidKeyUri

### DIFF
--- a/.changeset/did-key-uri-guard.md
+++ b/.changeset/did-key-uri-guard.md
@@ -1,0 +1,13 @@
+---
+"@agentcommercekit/did": patch
+---
+
+`isDidKeyUri` no longer accepts `did:key:z`, the multibase prefix carrying no
+key material. The check sliced from index 8 — the length of `"did:key:"`, not of
+`"did:key:z"` — so the `z` stayed in the string it tested and satisfied the `+`
+in `z[a-km-zA-HJ-NP-Z1-9]+` by itself. The guard therefore vouched for a DID
+that `getDidResolver().resolve()` reports as `invalidDid`. The check is now a
+single pattern spanning the whole URI, so the quantifier applies to the
+base58btc value as the documented grammar intends. Every other input is
+unaffected: `z` is itself a base58btc character, so it was the only string the
+old slice let through.

--- a/packages/did/src/methods/did-key.test.ts
+++ b/packages/did/src/methods/did-key.test.ts
@@ -61,4 +61,28 @@ describe("isDidKeyUri", () => {
   it("returns false for invalid did:key", () => {
     expect(isDidKeyUri("invalid-did-key")).toBe(false)
   })
+
+  it("returns false for a multibase prefix with no key material", () => {
+    expect(isDidKeyUri("did:key:z")).toBe(false)
+    expect(isDidKeyUri("did:key:")).toBe(false)
+  })
+
+  it("returns false for characters outside the base58btc alphabet", () => {
+    for (const char of ["0", "O", "I", "l"]) {
+      expect(isDidKeyUri(`did:key:z${char}`)).toBe(false)
+    }
+  })
+
+  it("returns false for a non-string", () => {
+    expect(isDidKeyUri(undefined)).toBe(false)
+    expect(isDidKeyUri(123)).toBe(false)
+  })
+
+  it("does not vouch for a did:key the resolver rejects", async () => {
+    const resolver = getDidResolver()
+    const resolved = await resolver.resolve("did:key:z")
+
+    expect(resolved.didResolutionMetadata.error).toBe("invalidDid")
+    expect(isDidKeyUri("did:key:z")).toBe(false)
+  })
 })

--- a/packages/did/src/methods/did-key.ts
+++ b/packages/did/src/methods/did-key.ts
@@ -37,6 +37,13 @@ export const KEY_CONFIG = {
 } as const
 
 /**
+ * The `did:key` grammar documented on {@link isDidKeyUri}, as a single pattern.
+ * The `+` applies to the base58btc value that follows the `z`, so the multibase
+ * prefix on its own is not a `did:key` URI.
+ */
+const didKeyUriRegex = /^did:key:z[a-km-zA-HJ-NP-Z1-9]+$/
+
+/**
  * Checks if a given item is a valid did:key URI, according to the following format:
  *  did-key-format := did:key:<mb-value>
  *  mb-value       := z[a-km-zA-HJ-NP-Z1-9]+
@@ -45,12 +52,7 @@ export const KEY_CONFIG = {
  * @returns `true` if the value is a did:key URI, `false` otherwise
  */
 export function isDidKeyUri(did: unknown): did is DidKeyUri {
-  if (typeof did !== "string" || !did.startsWith("did:key:z")) {
-    return false
-  }
-
-  const mbValue = did.slice(8) // Get everything after "did:key:z"
-  return /^[a-km-zA-HJ-NP-Z1-9]+$/.test(mbValue)
+  return typeof did === "string" && didKeyUriRegex.test(did)
 }
 
 /**


### PR DESCRIPTION
`isDidKeyUri` returns `true` for `did:key:z` — the multibase prefix with no key material behind it.

```ts
import { isDidKeyUri, getDidResolver } from "@agentcommercekit/did"

isDidKeyUri("did:key:z") // true

await getDidResolver().resolve("did:key:z")
// { didDocument: null, didResolutionMetadata: { error: "invalidDid" } }
```

So the guard vouches for a DID the resolver in this same package rejects. Anything that narrows to `DidKeyUri` on the strength of it is holding a value with no key bytes in it.

## Why

The check slices the multibase value off by index:

```ts
if (typeof did !== "string" || !did.startsWith("did:key:z")) {
  return false
}

const mbValue = did.slice(8) // Get everything after "did:key:z"
return /^[a-km-zA-HJ-NP-Z1-9]+$/.test(mbValue)
```

`"did:key:"` is 8 characters and `"did:key:z"` is 9, so `slice(8)` keeps the `z` — the comment describes the intent, not what the line does. `z` is itself a base58btc character, so it satisfies the `+` on its own and the empty value passes. The grammar quoted directly above the function requires at least one character after the prefix:

```
did-key-format := did:key:<mb-value>
mb-value       := z[a-km-zA-HJ-NP-Z1-9]+
```

## Change

The guard is now the grammar as one pattern over the whole URI, so the quantifier lands on the base58btc value and there is no index to get wrong:

```ts
const didKeyUriRegex = /^did:key:z[a-km-zA-HJ-NP-Z1-9]+$/
```

This is the same shape `createDidKeyUri`'s existing tests already assert its output against, so the two now agree on what a `did:key` URI is.

`did:key:z` is the only string whose result changes. The old slice differed from a correct one only by the leading `z`, and since `z` is in the character class, every other input was already classified the same way.

## Tests

Added to the existing `isDidKeyUri` block in `packages/did/src/methods/did-key.test.ts`:

- `did:key:z` and `did:key:` are rejected
- characters outside the base58btc alphabet (`0`, `O`, `I`, `l`) are rejected
- non-string input is rejected
- the guard and `getDidResolver().resolve()` agree on `did:key:z`

The first and last fail on `main`. `packages/did` is green (74 tests), `oxlint` reports nothing on the changed files, and `oxfmt --check` passes on them.

One note on my local run: `packages/did/src/did-resolvers/pkh-did-resolver.test.ts` cannot run on Windows because the `did-pkh` fixture filenames contain `:`, which is what #145 describes. That is unrelated to this change and I left it alone.

## AI assistance disclosure

Per the repository AI policy: this contribution was AI-assisted using Claude Code (Claude Opus). AI assistance was used to locate the defect, write the fix and the tests, and run verification locally. I reviewed the final diff, can explain the change and why it is confined to a single input, and take responsibility for what is submitted here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `did:key` URI validation to require valid key material.
  * Invalid identifiers, including incomplete keys and those with unsupported characters, are now rejected.
  * Non-string inputs and identifiers rejected by the resolver are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->