### PR TITLE
fix(did,keys): emit a real Multikey for `publicKeyMultibase`

### DIFF
--- a/.changeset/multikey-public-key-multibase.md
+++ b/.changeset/multikey-public-key-multibase.md
@@ -1,0 +1,32 @@
+---
+"@agentcommercekit/keys": minor
+"@agentcommercekit/did": minor
+---
+
+`publicKeyMultibase` on a `Multikey` verification method is now an actual
+Multikey: `multibase(base58-btc, varint(multicodec code) ‖ key-bytes)`, with
+secp256k1 and secp256r1 keys in their 33-byte compressed form. It previously
+multibase-encoded the raw public key bytes, so the value carried no algorithm
+identifier and a relying party could not tell one curve's key from another's.
+`createDidKeyUri` already built the prefixed form, so the same key came out two
+different ways depending on which function produced it; the two now agree, and
+`publicKeyMultibase` equals the `did:key` method-specific identifier for the
+same key.
+
+This changes the value emitted by `createDidDocument`,
+`createDidDocumentFromKeypair`, `createDidWebDocument` and
+`encodePublicKey("multibase", ...)`, for the `multibase`, `hex` and `base58`
+encodings — `hex` and `base58` are converted to a `Multikey` verification
+method, so they carry the same value. Documents built with the default `jwk`
+encoding are unaffected. A document published with the old value keeps whatever
+it was published with; re-generating it produces the corrected value.
+
+`encodePublicKey("multibase", bytes, curve)` now throws for `secp256k1` and
+`secp256r1` when `bytes` is not a point on that curve, since compressing it
+requires decoding it. It previously accepted any bytes and encoded them, which
+is how a value that was not a key could end up in a `Multikey`. Ed25519 is
+unaffected: it has a single 32-byte encoding and no compression step.
+
+Adds `publicKeyToMultikey(publicKey, curve)` and `keyCurveMulticodecs` to
+`@agentcommercekit/keys`, plus `compressPublicKey` on the `secp256k1` and
+`secp256r1` curve modules.

--- a/.changeset/multikey-public-key-multibase.md
+++ b/.changeset/multikey-public-key-multibase.md
@@ -21,11 +21,11 @@ method, so they carry the same value. Documents built with the default `jwk`
 encoding are unaffected. A document published with the old value keeps whatever
 it was published with; re-generating it produces the corrected value.
 
-`encodePublicKey("multibase", bytes, curve)` now throws for `secp256k1` and
-`secp256r1` when `bytes` is not a point on that curve, since compressing it
-requires decoding it. It previously accepted any bytes and encoded them, which
-is how a value that was not a key could end up in a `Multikey`. Ed25519 is
-unaffected: it has a single 32-byte encoding and no compression step.
+`encodePublicKey("multibase", bytes, curve)` now throws when `bytes` is not a
+public key on `curve`, for every curve. It previously accepted any bytes and
+encoded them, which is how a value that was not a key could end up in a
+`Multikey` — and a Multikey states which curve its key is on, so bytes that are
+not a key on that curve must not carry one of these prefixes.
 
 Adds `publicKeyToMultikey(publicKey, curve)` and `keyCurveMulticodecs` to
 `@agentcommercekit/keys`, plus `compressPublicKey` on the `secp256k1` and

--- a/packages/did/src/create-did-document.test.ts
+++ b/packages/did/src/create-did-document.test.ts
@@ -3,19 +3,18 @@ import {
   generateKeypair,
   keyCurves,
   publicKeyEncodings,
+  publicKeyToMultikey,
   type Keypair,
   type PublicKeyEncoding,
 } from "@agentcommercekit/keys"
-import {
-  bytesToMultibase,
-  publicKeyBytesToJwk,
-} from "@agentcommercekit/keys/encoding"
+import { publicKeyBytesToJwk } from "@agentcommercekit/keys/encoding"
 import { beforeEach, describe, expect, test } from "vitest"
 
 import {
   createDidDocument,
   createDidDocumentFromKeypair,
 } from "./create-did-document"
+import { createDidKeyUri } from "./methods/did-key"
 
 const keyTypeMap = {
   jwk: "JsonWebKey2020",
@@ -87,7 +86,10 @@ describe("createDidDocument() and createDidDocumentFromKeypair()", () => {
                   id: keyId,
                   type: keyTypeMap[encoding],
                   controller: did,
-                  publicKeyMultibase: bytesToMultibase(keypair.publicKey),
+                  publicKeyMultibase: publicKeyToMultikey(
+                    keypair.publicKey,
+                    curve,
+                  ),
                 }
 
           const expectedDocument = {
@@ -105,6 +107,28 @@ describe("createDidDocument() and createDidDocumentFromKeypair()", () => {
         })
       },
     )
+  })
+
+  describe.each(keyCurves)("Multikey encoding: %s", (curve) => {
+    test("publicKeyMultibase matches the did:key identifier for the key", () => {
+      const keypair = keypairMap[curve]()
+      const expected = createDidKeyUri(keypair).slice("did:key:".length)
+
+      // A Multikey and a did:key identifier are the same construction, so
+      // every encoding that resolves to a Multikey must produce this value
+      for (const encoding of ["multibase", "hex", "base58"] as const) {
+        const document = createDidDocumentFromKeypair({
+          did,
+          keypair,
+          encoding,
+        })
+
+        expect(document.verificationMethod?.[0]?.type).toBe("Multikey")
+        expect(document.verificationMethod?.[0]?.publicKeyMultibase).toBe(
+          expected,
+        )
+      }
+    })
   })
 
   test("includes controller when provided", () => {

--- a/packages/did/src/create-did-document.ts
+++ b/packages/did/src/create-did-document.ts
@@ -1,4 +1,5 @@
 import {
+  encodePublicKey,
   encodePublicKeyFromKeypair,
   type KeyCurve,
   type Keypair,
@@ -8,7 +9,6 @@ import {
 } from "@agentcommercekit/keys"
 import {
   base58ToBytes,
-  bytesToMultibase,
   hexStringToBytes,
 } from "@agentcommercekit/keys/encoding"
 import type { VerificationMethod } from "did-resolver"
@@ -68,17 +68,17 @@ function convertLegacyPublicKeyToMultibase(
 ): DidDocumentPublicKey {
   switch (publicKey.encoding) {
     case "hex":
-      return {
-        encoding: "multibase",
-        curve: publicKey.curve,
-        value: bytesToMultibase(hexStringToBytes(publicKey.value)),
-      }
+      return encodePublicKey(
+        "multibase",
+        hexStringToBytes(publicKey.value),
+        publicKey.curve,
+      )
     case "base58":
-      return {
-        encoding: "multibase",
-        curve: publicKey.curve,
-        value: bytesToMultibase(base58ToBytes(publicKey.value)),
-      }
+      return encodePublicKey(
+        "multibase",
+        base58ToBytes(publicKey.value),
+        publicKey.curve,
+      )
     default:
       return publicKey
   }

--- a/packages/did/src/did-resolvers/did-resolver.test.ts
+++ b/packages/did/src/did-resolvers/did-resolver.test.ts
@@ -11,7 +11,10 @@ describe("DidResolver", () => {
     publicKey: {
       encoding: "hex",
       curve: "secp256k1",
-      value: "0xc0ffee254729296a45a3885639AC7E10F9d54979",
+      // Uncompressed secp256k1 public key, matching the fixture in
+      // `methods/did-key.test.ts`
+      value:
+        "0x040bbd0a3fd05709d2814df8ed91003dc47eeecdded1f21602e9c4a913a094a6bada499b1fb61333e449d86e7de9489dc640774a21baea08bd86db2b8a8a7beba8",
     },
   })
 

--- a/packages/did/src/methods/did-web.test.ts
+++ b/packages/did/src/methods/did-web.test.ts
@@ -1,7 +1,6 @@
-import { generateKeypair } from "@agentcommercekit/keys"
+import { generateKeypair, publicKeyToMultikey } from "@agentcommercekit/keys"
 import {
   bytesToHexString,
-  bytesToMultibase,
   publicKeyBytesToJwk,
 } from "@agentcommercekit/keys/encoding"
 import { describe, expect, it } from "vitest"
@@ -66,7 +65,10 @@ describe("createDidWebDocument", () => {
   it("generates a valid DidUri and DidDocument, upgrading legacy hex to multibase", async () => {
     const keypair = await generateKeypair("secp256k1")
     const publicKeyHex = bytesToHexString(keypair.publicKey)
-    const publicKeyMultibase = bytesToMultibase(keypair.publicKey)
+    const publicKeyMultibase = publicKeyToMultikey(
+      keypair.publicKey,
+      keypair.curve,
+    )
 
     const { did, didDocument } = createDidWebDocument({
       publicKey: {

--- a/packages/keys/src/curves/secp256k1.ts
+++ b/packages/keys/src/curves/secp256k1.ts
@@ -35,6 +35,17 @@ export async function generateKeypair(
 }
 
 /**
+ * Compress a public key to its 33-byte form. Already-compressed keys are
+ * returned unchanged.
+ *
+ * @param pubkey - The public key bytes to compress
+ * @returns The compressed public key bytes
+ */
+export function compressPublicKey(pubkey: Uint8Array): Uint8Array {
+  return secp256k1.Point.fromBytes(pubkey).toBytes(true)
+}
+
+/**
  * Check if a public key is a valid secp256k1 public key (either compressed or
  * uncompressed)
  * @param pubkey - The public key bytes to check

--- a/packages/keys/src/curves/secp256r1.ts
+++ b/packages/keys/src/curves/secp256r1.ts
@@ -35,6 +35,17 @@ export async function generateKeypair(
 }
 
 /**
+ * Compress a public key to its 33-byte form. Already-compressed keys are
+ * returned unchanged.
+ *
+ * @param pubkey - The public key bytes to compress
+ * @returns The compressed public key bytes
+ */
+export function compressPublicKey(pubkey: Uint8Array): Uint8Array {
+  return secp256r1.Point.fromBytes(pubkey).toBytes(true)
+}
+
+/**
  * Check if a public key is a valid secp256r1 public key (either compressed or
  * uncompressed)
  * @param pubkey - The public key bytes to check

--- a/packages/keys/src/key-curves.ts
+++ b/packages/keys/src/key-curves.ts
@@ -1,6 +1,21 @@
 export const keyCurves = ["secp256k1", "secp256r1", "Ed25519"] as const
 export type KeyCurve = (typeof keyCurves)[number]
 
+/**
+ * The multicodec code identifying each curve's public key.
+ *
+ * A Multikey value is `multibase(base58-btc, varint(code) ‖ key-bytes)`, so
+ * these are what let a reader tell one curve's key from another's. The codes
+ * for the two elliptic curves identify the compressed point encoding.
+ *
+ * @see {@link https://github.com/multiformats/multicodec/blob/master/table.csv}
+ */
+export const keyCurveMulticodecs = {
+  secp256k1: 0xe7, // secp256k1-pub
+  secp256r1: 0x1200, // p256-pub
+  Ed25519: 0xed, // ed25519-pub
+} as const satisfies Record<KeyCurve, number>
+
 export function isKeyCurve(curve: unknown): curve is KeyCurve {
   if (typeof curve !== "string") {
     return false

--- a/packages/keys/src/public-key.test.ts
+++ b/packages/keys/src/public-key.test.ts
@@ -1,3 +1,4 @@
+import { varint } from "multiformats"
 import { describe, expect, test } from "vitest"
 
 import { isBase58 } from "./encoding/base58"
@@ -8,10 +9,14 @@ import {
   isPublicKeyJwkSecp256k1,
   isPublicKeyJwkSecp256r1,
 } from "./encoding/jwk"
-import { isMultibase } from "./encoding/multibase"
-import { keyCurves, type KeyCurve } from "./key-curves"
+import { isMultibase, multibaseToBytes } from "./encoding/multibase"
+import { keyCurveMulticodecs, keyCurves, type KeyCurve } from "./key-curves"
 import { generateKeypair } from "./keypair"
-import { encodePublicKeyFromKeypair, isValidPublicKey } from "./public-key"
+import {
+  encodePublicKeyFromKeypair,
+  isValidPublicKey,
+  publicKeyToMultikey,
+} from "./public-key"
 
 const ecCurves = ["secp256k1", "secp256r1"] as const satisfies KeyCurve[]
 
@@ -40,6 +45,24 @@ describe("public-key methods", () => {
       const keypair = await generateKeypair(curve)
       const publicKey = encodePublicKeyFromKeypair("multibase", keypair)
       expect(isMultibase(publicKey.value)).toBe(true)
+    })
+
+    test("encodes public key as a Multikey", async () => {
+      const keypair = await generateKeypair(curve)
+      const value = publicKeyToMultikey(keypair.publicKey, curve)
+
+      expect(encodePublicKeyFromKeypair("multibase", keypair).value).toBe(value)
+
+      const bytes = multibaseToBytes(value)
+      const [code, prefixLength] = varint.decode(bytes)
+
+      // The multicodec code identifies the curve, so a reader can tell one
+      // curve's key from another's
+      expect(code).toBe(keyCurveMulticodecs[curve])
+
+      // Ed25519 has a single 32-byte encoding; the EC curves use their
+      // 33-byte compressed form, which is what their codes identify
+      expect(bytes.length - prefixLength).toBe(curve === "Ed25519" ? 32 : 33)
     })
 
     test("encodes public key to base58", async () => {

--- a/packages/keys/src/public-key.test.ts
+++ b/packages/keys/src/public-key.test.ts
@@ -65,6 +65,24 @@ describe("public-key methods", () => {
       expect(bytes.length - prefixLength).toBe(curve === "Ed25519" ? 32 : 33)
     })
 
+    test("throws when the bytes are not a public key on the curve", async () => {
+      const keypair = await generateKeypair(curve)
+
+      // The message asserts the rejection comes from the curve check, rather
+      // than incidentally from decoding an EC point
+      const message = `Invalid ${curve} public key`
+
+      // Wrong length for every curve
+      expect(() => publicKeyToMultikey(new Uint8Array(20), curve)).toThrow(
+        message,
+      )
+
+      // Right length for the curve, but not a point on it
+      const notOnCurve = new Uint8Array(keypair.publicKey.length).fill(0xff)
+      expect(isValidPublicKey(notOnCurve, curve)).toBe(false)
+      expect(() => publicKeyToMultikey(notOnCurve, curve)).toThrow(message)
+    })
+
     test("encodes public key to base58", async () => {
       const keypair = await generateKeypair(curve)
       const publicKey = encodePublicKeyFromKeypair("base58", keypair)

--- a/packages/keys/src/public-key.ts
+++ b/packages/keys/src/public-key.ts
@@ -102,11 +102,18 @@ function compressPublicKey(publicKey: Uint8Array, curve: KeyCurve): Uint8Array {
  * @param publicKey - The raw public key bytes
  * @param curve - The curve the key belongs to
  * @returns The Multikey string
+ * @throws If `publicKey` is not a valid public key on `curve`
  */
 export function publicKeyToMultikey(
   publicKey: Uint8Array,
   curve: KeyCurve,
 ): string {
+  // A Multikey says which curve its key is on, so bytes that are not a key on
+  // that curve must not get one of these prefixes.
+  if (!isValidPublicKey(publicKey, curve)) {
+    throw new Error(`Invalid ${curve} public key`)
+  }
+
   const compressed = compressPublicKey(publicKey, curve)
   const code = keyCurveMulticodecs[curve]
   const prefix = new Uint8Array(varint.encodingLength(code))

--- a/packages/keys/src/public-key.ts
+++ b/packages/keys/src/public-key.ts
@@ -1,3 +1,5 @@
+import { varint } from "multiformats"
+
 import * as ed25519 from "./curves/ed25519"
 import * as secp256k1 from "./curves/secp256k1"
 import * as secp256r1 from "./curves/secp256r1"
@@ -5,7 +7,7 @@ import { bytesToBase58 } from "./encoding/base58"
 import { bytesToHexString } from "./encoding/hex"
 import { publicKeyBytesToJwk, type PublicKeyJwk } from "./encoding/jwk"
 import { bytesToMultibase } from "./encoding/multibase"
-import type { KeyCurve } from "./key-curves"
+import { keyCurveMulticodecs, type KeyCurve } from "./key-curves"
 import type { Keypair } from "./keypair"
 
 /**
@@ -74,6 +76,50 @@ export function isValidPublicKey(
 }
 
 /**
+ * Compress a public key, for curves that have a compressed point encoding.
+ * Ed25519 keys have a single 32-byte encoding and are returned unchanged.
+ */
+function compressPublicKey(publicKey: Uint8Array, curve: KeyCurve): Uint8Array {
+  if (curve === "secp256k1") {
+    return secp256k1.compressPublicKey(publicKey)
+  }
+
+  if (curve === "secp256r1") {
+    return secp256r1.compressPublicKey(publicKey)
+  }
+
+  return publicKey
+}
+
+/**
+ * Encode a public key as a Multikey: the curve's multicodec code as a varint,
+ * followed by the key bytes, multibase-encoded with base58-btc.
+ *
+ * This is the value a `Multikey` verification method's `publicKeyMultibase`
+ * holds, and it is the same value that follows `did:key:` in a `did:key` URI
+ * for the same key.
+ *
+ * @param publicKey - The raw public key bytes
+ * @param curve - The curve the key belongs to
+ * @returns The Multikey string
+ */
+export function publicKeyToMultikey(
+  publicKey: Uint8Array,
+  curve: KeyCurve,
+): string {
+  const compressed = compressPublicKey(publicKey, curve)
+  const code = keyCurveMulticodecs[curve]
+  const prefix = new Uint8Array(varint.encodingLength(code))
+  varint.encodeTo(code, prefix, 0)
+
+  const prefixed = new Uint8Array(prefix.length + compressed.length)
+  prefixed.set(prefix)
+  prefixed.set(compressed, prefix.length)
+
+  return bytesToMultibase(prefixed)
+}
+
+/**
  * Convert a public key to a multibase string (used for DID:key)
  */
 function encodePublicKeyMultibase(
@@ -83,7 +129,7 @@ function encodePublicKeyMultibase(
   return {
     encoding: "multibase",
     curve,
-    value: bytesToMultibase(publicKey),
+    value: publicKeyToMultikey(publicKey, curve),
   }
 }
 


### PR DESCRIPTION
Fixes #165.

`createDidDocument` builds verification methods with `type: "Multikey"`, but the `publicKeyMultibase` on them was a multibase encoding of the raw public key bytes. A Multikey is `multibase(base58-btc, varint(multicodec code) ‖ key-bytes)`, so the value carried no algorithm identifier — a relying party reading it as a Multikey cannot tell an Ed25519 key from a P-256 one. `createDidKeyUri` already built the prefixed form, so the same key came out two different ways depending on which function produced it.

Using the two keypairs fixtured in `packages/did/src/methods/did-key.test.ts`:

| curve | before | after (= `createDidKeyUri`) |
| --- | --- | --- |
| Ed25519 | `z8myPWEuZj3T3WzBQu281AeLzE3pmU9h7em1YEGiD6ick` | `z6MknEES6VA14awWdV27ab5r1jtz3d6ct2wULmvU4YgE1wQ8` |
| secp256k1 | `zMi3oP598f15BeBYp3tdwtNEE3omWSogmoT8Q5ckb1N5AKKJj59KU61vMYYncCBDzGDaDkn7zib2ACobFPXB8TjGT` | `zQ3shNCcRrVT3tm43o6JNjSjQaiBXvSb8kHtFhoNGR8eimFZs` |

## Change

`publicKeyToMultikey(publicKey, curve)` in `@agentcommercekit/keys` prepends the curve's multicodec code as a varint and multibase-encodes the result. `encodePublicKeyMultibase` uses it, and `convertLegacyPublicKeyToMultibase` in `@agentcommercekit/did` routes `hex` and `base58` through the same encoder rather than calling `bytesToMultibase` directly — those two are converted to a `Multikey` verification method as well, so they carried the same defect.

The codes live in a new `keyCurveMulticodecs` map in `keys`, next to `keyCurves`. That is the placement decision I flagged in the issue: `keys` already owns curve metadata, key generation and every other encoding, and it is the package the encoder lives in. `KEY_CONFIG` in `did/methods/did-key.ts` is untouched, so nothing about `did:key` changes — instead the new test asserts the two agree, which is what keeps them from drifting apart again.

secp256k1 and secp256r1 keys are compressed to the 33-byte form their codes identify, via a new `compressPublicKey` on each curve module (`Point.fromBytes(...).toBytes(true)`, the same `@noble/curves` API `isValidPublicKey` already uses). `generateKeypair` stores these uncompressed, which is why the secp256k1 row above is so long. Ed25519 has a single 32-byte encoding and is passed through.

## Behaviour changes

- The `publicKeyMultibase` emitted by `createDidDocument`, `createDidDocumentFromKeypair`, `createDidWebDocument` and `encodePublicKey("multibase", ...)` changes for the `multibase`, `hex` and `base58` encodings. The default `jwk` encoding is unaffected. An already-published document keeps whatever it was published with; re-generating it produces the corrected value. Marked `minor` on both packages.
- `encodePublicKey("multibase", bytes, curve)` now throws for `secp256k1`/`secp256r1` when `bytes` is not a point on that curve, because compressing it means decoding it. This surfaced in `did-resolvers/did-resolver.test.ts`, which passed a 20-byte Ethereum address as a secp256k1 public key; that fixture is now a real key from `did-key.test.ts`. The test exercises the resolver cache, so the key material is incidental to it. Happy to make the compression lenient instead if you would rather this path keep accepting arbitrary bytes, though that would put non-keys back into `Multikey` values.

## Tests

- `keys`: the multibase encoding decodes to the curve's multicodec code followed by a key of the expected length (32 for Ed25519, 33 for the EC curves).
- `did`: for every curve, `publicKeyMultibase` equals the `did:key` identifier for the same key, across the `multibase`, `hex` and `base58` encodings — asserted against `createDidKeyUri`, which is independent of the code being changed.
- Two existing expectations that encoded the old value (`create-did-document.test.ts`, `methods/did-web.test.ts`) now build theirs with `publicKeyToMultikey`.

Both new tests fail on `main`. `keys` (102), `did` (73), `vc` (109), `ack-id` (39) and `ack-pay` (34) pass; `oxlint` and `oxfmt --check` are clean on the changed files.

One note on my local run: `packages/did/src/did-resolvers/pkh-did-resolver.test.ts` cannot run on Windows because the `did-pkh` fixture filenames contain `:`, which is #145. Unrelated to this change and left alone.

## AI assistance disclosure

Per the repository AI policy: this contribution was AI-assisted using Claude Code (Claude Opus). AI assistance was used to find the inconsistency, write the change and the tests, and run verification locally. I reviewed the final diff, can explain what it does and where it changes behaviour, and take responsibility for what is submitted here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public keys now use Multikey encoding compatible with `did:key` identifiers.
  * Added support for compressed secp256k1 and secp256r1 public keys.
  * Added curve-specific public-key compression and Multicodec mapping APIs.
* **Bug Fixes**
  * Invalid public keys are now rejected during multibase encoding.
  * Legacy hex and Base58 keys are converted using the correct Multikey format.
  * JWK output remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->