### PR TITLE
Prevent unauthorized redirects in fetch options

### DIFF
--- a/packages/did/src/did-resolvers/web-did-resolver.ts
+++ b/packages/did/src/did-resolvers/web-did-resolver.ts
@@ -74,6 +74,7 @@ async function fetchDidDocumentAtUrl(
 ): Promise<DidDocument> {
   const res = await fetch(url, {
     mode: "cors",
+    redirect: "error", // Following a redirect would send the request to a host the check never saw, which is how a status list URL becomes a probe for internal addresses (same threat model as is-revoked.ts).
     ...(timeout !== undefined ? { signal: AbortSignal.timeout(timeout) } : {}),
   })
 


### PR DESCRIPTION
Found a Server-Side Request Forgery (SSRF) vulnerability in the did:web resolver and wanted to report it responsibly per your SECURITY.md.

Location: packages/did/src/did-resolvers/web-did-resolver.ts, function fetchDidDocumentAtUrl

Issue: The fetch() call used to retrieve a did:web document did not restrict redirect behavior, so it used the Fetch API default of automatically following redirects.

Since the URL is derived directly from an attacker-controlled did:web identifier, an attacker can register a did:web pointing at a server they control, have that server respond with a redirect (e.g. 302) to an internal address (cloud metadata endpoints such as 169.254.169.254, internal admin services, etc.), and any service that resolves that DID will follow the redirect and issue a request to the attacker-chosen internal target.

Why I think this is unintentional: the exact same threat model is already identified and mitigated elsewhere in this codebase, in packages/vc/src/verification/is-revoked.ts, which explicitly sets redirect: "error" on its status-list fetch with this comment: "Following a redirect would send the request to a host the check never saw, which is how a status list URL becomes a probe for internal addresses." That fetch even has a dedicated test ("refuses to follow a redirect away from the status list URL" in is-revoked.test.ts). The did:web resolver had no equivalent test or protection, which suggests this was simply missed rather than a deliberate design choice.

Impact: did:web resolution sits underneath most of ACK's trust decisions (JWT issuer resolution, credential issuer resolution, payment receipt verification, controller resolution), so any service using this resolver to process untrusted DIDs is exposed to SSRF, with the usual downstream risks (internal network probing, and in cloud deployments, potential credential exposure via metadata endpoints).

Fix: Added redirect: "error" to the fetch() call in fetchDidDocumentAtUrl, matching the existing pattern in is-revoked.ts.

Originally reported by email and in the Catena Discord. Sharing details here too since matt suggested opening a PR directly. Happy to add a regression test in the same style as is-revoked.test.ts if that would help, just let me know the preferred approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - DID document requests now reject redirected URLs instead of automatically following them, improving resolution security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->