### PR TITLE
fix(ack-id): return reply nonce for response handshakes

### DIFF
--- a/.changeset/fresh-reply-nonce.md
+++ b/.changeset/fresh-reply-nonce.md
@@ -1,0 +1,5 @@
+---
+"@agentcommercekit/ack-id": patch
+---
+
+Return the fresh reply nonce from A2A response handshakes so callers can correlate the next handshake leg.

--- a/packages/ack-id/src/a2a/sign-message.test.ts
+++ b/packages/ack-id/src/a2a/sign-message.test.ts
@@ -138,6 +138,20 @@ describe("createA2AHandshakeMessage", () => {
     expect(result.message.role).toBe("agent")
   })
 
+  it("returns the fresh reply nonce when responding to a handshake", async () => {
+    const result = await createA2AHandshakeMessage(
+      "agent",
+      {
+        recipient: userDid,
+        vc: testCredential,
+        requestNonce: "original-nonce",
+      },
+      { did: agentDid, jwtSigner },
+    )
+
+    expect(result.nonce).toBe("test-nonce-1234")
+  })
+
   it("returns the signed JWT in the message data part", async () => {
     const result = await createA2AHandshakeMessage(
       "agent",

--- a/packages/ack-id/src/a2a/sign-message.ts
+++ b/packages/ack-id/src/a2a/sign-message.ts
@@ -122,7 +122,7 @@ export async function createA2AHandshakeMessage(
   return {
     sig: jwt,
     jti,
-    nonce: payload.nonce,
+    nonce: payload.replyNonce ?? payload.nonce,
     message,
   }
 }


### PR DESCRIPTION
## Summary

Fixes #174

`createA2AHandshakeMessage()` returned `payload.nonce` for every handshake message.

For response handshakes, `createA2AHandshakePayload({ requestNonce })` keeps the peer's original request nonce in `payload.nonce` and puts the newly generated nonce in `payload.replyNonce`. Returning `payload.nonce` meant callers received the old request nonce instead of the fresh reply nonce needed to correlate the next handshake leg.

This PR returns `payload.replyNonce` when present, while preserving the existing initiator behavior by falling back to `payload.nonce`.

---

## Changes

- Return `payload.replyNonce ?? payload.nonce` from `createA2AHandshakeMessage()`.
- Add a regression test for response handshakes with `requestNonce`.

---

## How to Test

```bash
pnpm --filter @agentcommercekit/ack-id test -- src/a2a/sign-message.test.ts
pnpm --filter @agentcommercekit/ack-id test
pnpm --filter @agentcommercekit/ack-id build
pnpm run lint
pnpm run check:format
pnpm run check:packages
git diff --check
```

**Note:** `pnpm run check` was also attempted. Build passed, but the full parallel test run hit Vitest fork worker timeout/EPIPE errors across unrelated packages in this WSL environment. The focused package tests and repo lint/format/package checks passed.

---

## Checklist

- [x] Tests pass — focused package tests green, new regression test added
- [x] Lint, format, and package checks pass
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only

---

## Risk & Impact

**Low.** The fallback (`payload.replyNonce ?? payload.nonce`) preserves the existing initiator behavior byte-for-byte — only response handshakes with a `replyNonce` present see a behavior change, which is the exact case this fixes.

**Type:** 🐛 Bug fix
**Fixes:** #174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved handshake responses to return the requested nonce when replying to an existing handshake.
- Initial handshakes continue to generate and return a fresh nonce.
- Callers can reliably correlate the next step in a handshake exchange.

## Tests

- Added coverage verifying nonce handling for both initial and response handshakes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->