### PR TITLE
fix(caip): allow hyphen in CAIP-2 namespace per spec

### DIFF
--- a/.changeset/curly-hyphens-parse.md
+++ b/.changeset/curly-hyphens-parse.md
@@ -1,0 +1,5 @@
+---
+"@agentcommercekit/caip": patch
+---
+
+Allow a hyphen in the CAIP-2 chain namespace, per spec (`namespace: [-a-z0-9]{3,8}`). `caip2NamespacePattern` previously omitted the hyphen, diverging from both the spec and the sibling `caip19AssetNamespacePattern`.

--- a/packages/caip/src/caips/caip-2.test.ts
+++ b/packages/caip/src/caips/caip-2.test.ts
@@ -82,6 +82,14 @@ describe("caip2ChainIdRegex", () => {
   it("rejects a chain ID without a colon", () => {
     expect(caip2ChainIdRegex.test("eip1551")).toBe(false)
   })
+
+  it("matches a chain ID with a hyphenated namespace", () => {
+    expect(caip2ChainIdRegex.test("foo-bar:1")).toBe(true)
+  })
+
+  it("rejects a namespace with an invalid character", () => {
+    expect(caip2ChainIdRegex.test("foo_bar:1")).toBe(false)
+  })
 })
 
 describe("caip2NamespaceRegex", () => {
@@ -89,8 +97,16 @@ describe("caip2NamespaceRegex", () => {
     expect(caip2NamespaceRegex.test("eip155")).toBe(true)
   })
 
+  it("matches a namespace with a hyphen", () => {
+    expect(caip2NamespaceRegex.test("foo-bar")).toBe(true)
+  })
+
   it("rejects a namespace with uppercase letters", () => {
     expect(caip2NamespaceRegex.test("EIP155")).toBe(false)
+  })
+
+  it("rejects a namespace with an underscore", () => {
+    expect(caip2NamespaceRegex.test("foo_bar")).toBe(false)
   })
 })
 

--- a/packages/caip/src/caips/caip-2.ts
+++ b/packages/caip/src/caips/caip-2.ts
@@ -3,7 +3,7 @@
  * @see {@link https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md}
  *
  * chain_id:    namespace + ":" + reference
- * namespace:   [a-z0-9]{3,8}
+ * namespace:   [-a-z0-9]{3,8}
  * reference:   [-_a-zA-Z0-9]{1,32}
  */
 
@@ -13,7 +13,7 @@ export type Caip2ChainIdParts = {
   reference: string
 }
 
-export const caip2NamespacePattern = "[a-z0-9]{3,8}"
+export const caip2NamespacePattern = "[-a-z0-9]{3,8}"
 export const caip2ReferencePattern = "[-_a-zA-Z0-9]{1,32}"
 export const caip2ChainIdPattern = `${caip2NamespacePattern}:${caip2ReferencePattern}`
 

--- a/packages/caip/src/schemas/schemas.test.ts
+++ b/packages/caip/src/schemas/schemas.test.ts
@@ -26,6 +26,7 @@ describe.each(Object.entries(schemasBySource))(
           "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
           "bitcoin:mainnet",
           "cosmos:cosmoshub-4",
+          "eip-155:1", // hyphen allowed in namespace
         ]
 
         for (const chainId of validChainIds) {
@@ -43,7 +44,7 @@ describe.each(Object.entries(schemasBySource))(
           "ab:1", // too short namespace
           "verylongnamespace:1", // too long namespace
           "EIP155:1", // uppercase not allowed in namespace
-          "eip-155:1", // hyphen not allowed in namespace
+          "eip_155:1", // underscore not allowed in namespace
         ]
 
         for (const chainId of invalidChainIds) {

--- a/packages/did/src/did-resolvers/pkh-did-resolver.test.ts
+++ b/packages/did/src/did-resolvers/pkh-did-resolver.test.ts
@@ -34,8 +34,10 @@ describe("pkh-did-resolver", () => {
     },
   )
 
-  it("returns an error for unknown did:pkh URIs", async () => {
-    const result = await resolve("did:pkh:eip-155:1:invalid")
+  it("returns an error for a structurally invalid did:pkh URI", async () => {
+    // Uppercase is not a valid CAIP-2 namespace character, independent of
+    // the hyphen allowance.
+    const result = await resolve("did:pkh:EIP155:1:invalid")
 
     expect(result).toEqual({
       didDocument: null,


### PR DESCRIPTION
`caip2NamespacePattern` (`packages/caip/src/caips/caip-2.ts`) was `"[a-z0-9]{3,8}"`, but the [CAIP-2 spec](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md) defines the namespace grammar as `[-a-z0-9]{3,8}`, hyphen included. The sibling `caip19AssetNamespacePattern` in `caip-19.ts` already uses the hyphenated form, and this file's own doc comment repeated the same wrong pattern, so the fix also corrects the comment for internal consistency. Added regression tests for a hyphenated namespace being accepted and an invalid character still being rejected, and a changeset for `@agentcommercekit/caip` (patch). One existing `did:pkh` resolver test's "invalid URI" fixture depended on the old regex rejecting a hyphenated namespace as its only source of invalidity; it's updated to use an uppercase namespace instead, which stays invalid for its own, unrelated, still-enforced reason.

**AI assistance disclosure:** This contribution was AI-assisted using Claude Code. AI was used to identify the spec discrepancy, implement the pattern/doc-comment fix, write the regression tests, and update the affected `did:pkh` test fixture. I reviewed the full diff and test output, understand the change and why the `did:pkh` test needed updating, and take responsibility for what's submitted here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - CAIP-2 chain identifiers now correctly accept hyphens in namespaces, in accordance with the specification.
  - Invalid underscore characters and uppercase namespace values continue to be rejected.

- **Tests**
  - Expanded validation coverage for hyphenated namespaces and invalid namespace formats.

- **Release**
  - Prepared a patch release for the CAIP package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->