### PR TITLE
chore(ack-pay): review polish follow-up for #120

### DIFF
--- a/.changeset/dedupe-timestamp-schema.md
+++ b/.changeset/dedupe-timestamp-schema.md
@@ -6,7 +6,6 @@ Reject invalid `expiresAt` values in `paymentRequestSchema` instead of throwing.
 
 Previously the `expiresAt` transform called `new Date(input).toISOString()`
 directly, so an unparseable value (e.g. `"invalid-date"`) threw a `RangeError`
-out of `safeParse` rather than producing a validation error. A shared
-`timestampSchema` now validates the date is parseable before normalizing it to
-an ISO string, and the valibot and zod schemas share the same accept/reject
-behavior.
+out of `safeParse` rather than producing a validation error. The schema now
+validates that the date is parseable before it normalizes the value to an ISO
+string, and the valibot and zod schemas share the same accept/reject behavior.

--- a/packages/ack-pay/src/schemas/schemas.test.ts
+++ b/packages/ack-pay/src/schemas/schemas.test.ts
@@ -1,8 +1,8 @@
 import * as v from "valibot"
 import { describe, expect, it } from "vitest"
 
-import { paymentRequestSchema as valibotPaymentRequestSchema } from "./schemas/valibot"
-import { paymentRequestSchema as zodPaymentRequestSchema } from "./schemas/zod"
+import { paymentRequestSchema as valibotPaymentRequestSchema } from "./valibot"
+import { paymentRequestSchema as zodPaymentRequestSchema } from "./zod"
 
 const paymentRequest = {
   id: "test-payment-request-id",


### PR DESCRIPTION
## Summary

Follow-up for the two Small / Optional polish notes on #120, kept out of that PR since it was already approved:

- Move `schemas.test.ts` to `packages/ack-pay/src/schemas/schemas.test.ts` next to the schemas it tests, imports now `./valibot` and `./zod` (repo rule: tests co-located with source)
- Reword the changeset so it no longer names `timestampSchema`, which is not an exported symbol consumers could find

Now that #120 has merged, this is rebased onto main and the diff is the single `chore(ack-pay)` commit: 2 files, +5/-6.

## Verification

- `pnpm run check` (build + format + type-aware lint + test) all green after the rebase
- `pnpm --filter ./packages/ack-pay test` 36 passing from the new location

## AI Usage Disclosure

This contribution was AI-assisted using Claude Code. AI assistance was used to apply the two review suggestions and run verification. I reviewed the final diff and take responsibility for the submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that payment request validation checks whether dates are parseable before converting them to ISO format.

- **Tests**
  - Updated schema test references to use the current module locations, ensuring validation tests continue to run correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->