### PR TITLE
chore(demos): point the identity demo at Claude Sonnet 5

### DIFF
--- a/demos/identity/src/get-model.ts
+++ b/demos/identity/src/get-model.ts
@@ -8,7 +8,7 @@ export const getModel = () => {
   if (process.env.ANTHROPIC_API_KEY) {
     return createAnthropic({
       apiKey: process.env.ANTHROPIC_API_KEY,
-    })("claude-3-7-sonnet-20250219")
+    })("claude-sonnet-5")
   } else if (process.env.OPENAI_API_KEY) {
     return createOpenAI({
       apiKey: process.env.OPENAI_API_KEY,


### PR DESCRIPTION
## Changes

- Identity demo Anthropic model id: `claude-3-7-sonnet-20250219` -> `claude-sonnet-5`

## Problem

The identity demo targets `claude-3-7-sonnet-20250219`, a deprecated model. Anyone running `pnpm demo:identity` with an Anthropic key hits a model that is on its way out.

## Solution

Use `claude-sonnet-5`, the current Sonnet. Current Anthropic model ids have no date suffix, so this id keeps tracking the latest Sonnet 5 release without further edits. The OpenAI branch (`gpt-4o`) is unchanged.

## Testing

- `oxlint` and `oxfmt` pass on the changed file
- The demo needs a live `ANTHROPIC_API_KEY`, so it was not run end to end

**AI usage:** Claude Code (Claude Fable 5) made the change and opened this PR at the author's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the Anthropic model selection to use the latest Claude Sonnet model identifier.
  - Existing provider selection and error handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->