### PR TITLE
docs(jwt): fix verifyJwt README example

### DIFF
--- a/packages/jwt/README.md
+++ b/packages/jwt/README.md
@@ -41,8 +41,8 @@ import { verifyJwt } from "@agentcommercekit/jwt"
 
 const resolver = getDidResolver()
 
-const parsed = await verifyJwt(payload, {
-  resolver: didResolver,
+const parsed = await verifyJwt(jwt, {
+  resolver,
 })
 
 console.log(parsed.payload)


### PR DESCRIPTION
## Problem

The verify example defined `const resolver = getDidResolver()` but passed `didResolver`, and used an undefined `payload` as the first argument. Copy-pasting the block as written would not run.

## Fix

Pass the `jwt` created in the example above and use the `resolver` variable that is actually in scope.

## AI usage

Per [AI_POLICY.md](https://github.com/agentcommercekit/ack/blob/main/AI_POLICY.md), Cursor spotted the broken example during a docs scan of main. I read the diff before opening this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the “Verify a JWT” example to use the generated token and resolver consistently.
  * Improved the example’s accuracy and ease of use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->