### PR TITLE
docs(ack-id): fix README typo, link, and type guard exports

### DIFF
--- a/packages/ack-id/README.md
+++ b/packages/ack-id/README.md
@@ -126,12 +126,15 @@ const handshake = await createA2AHandshakeMessage(
 #### 2. Counterparty Agent verifies and responds
 
 ```ts
-import { verifyA2AHandshakeMessage, createA2AHandshakeMessage } from "@agentcommercekit/ack-id/a2a"
+import {
+  verifyA2AHandshakeMessage,
+  createA2AHandshakeMessage,
+} from "@agentcommercekit/ack-id/a2a"
 
 // On receiving handshake message from customer
 const payload = await verifyA2AHandshakeMessage(handshake.message, {
   did: "did:web:bank.example.com",
-  counterparty: "did:web:customer.example.com"
+  counterparty: "did:web:customer.example.com",
 })
 // payload.nonce is the customer's nonce
 
@@ -143,8 +146,7 @@ const response = await createA2AHandshakeMessage(
     did: "did:web:bank.example.com",
     requestNonce: payload.nonce,
     // ...
-
-  }
+  },
 )
 // Send response to the customer
 ```

--- a/packages/ack-id/README.md
+++ b/packages/ack-id/README.md
@@ -63,16 +63,10 @@ try {
 ### Type Guards for Credential Validation
 
 ```ts
-import {
-  isControllerClaim,
-  isControllerCredential,
-} from "@agentcommercekit/ack-id"
+import { isControllerCredential } from "@agentcommercekit/ack-id"
 
 // Check if a credential is specifically a controller credential
 isControllerCredential(credential)
-
-// Check if a credential subject has the controller claim structure
-isControllerClaim(credential.credentialSubject)
 ```
 
 ## API Reference
@@ -81,7 +75,6 @@ isControllerClaim(credential.credentialSubject)
 
 - `createControllerCredential(params: CreateControllerCredentialParams): W3CCredential` - Creates a verifiable credential that establishes a controller relationship
 - `isControllerCredential(credential: unknown): credential is ControllerCredential` - Type guard for controller credentials
-- `isControllerClaim(credentialSubject: CredentialSubject): boolean` - Type guard for controller claims
 - `getControllerClaimVerifier(): ClaimVerifier` - Returns a verifier that can validate controller claims
 
 ### Schema Validation
@@ -97,7 +90,7 @@ import { controllerClaimSchema } from "@agentcommercekit/ack-id/schemas/zod"
 
 ## A2A Support
 
-This package includes utilities for building secure, mutually authenticated agent-to-agent (A2A) flows using DIDs and JWTs, as demonstrated in the [demo-identity-a2a](../docs/demos/demo-identity-a2a.mdx).
+This package includes utilities for building secure, mutually authenticated agent-to-agent (A2A) flows using DIDs and JWTs, as demonstrated in the [demo-identity-a2a](../../docs/demos/demo-identity-a2a.mdx).
 
 ### Key Exports from `@agentcommercekit/ack-id/a2a`
 
@@ -143,7 +136,7 @@ const payload = await verifyA2AHandshakeMessage(handshake.message, {
 // payload.nonce is the customer's nonce
 
 // Respond with a handshake message including the received nonce
-t const response = await createA2AHandshakeMessage(
+const response = await createA2AHandshakeMessage(
   "agent",
   "did:web:customer.example.com",
   {


### PR DESCRIPTION
## Problem

The ack-id README had three copy-paste issues:

- The A2A handshake example started with `t const response`, which is invalid TypeScript.
- The demo link used `../docs/demos/demo-identity-a2a.mdx`, which resolves to `packages/docs/...` and 404s from the package README. The file lives at `docs/demos/demo-identity-a2a.mdx`.
- The README documented `isControllerClaim`, which is not exported from the package. The public type guard is `isControllerCredential`.

## Fix

Correct the typo, fix the relative link to `../../docs/demos/demo-identity-a2a.mdx`, and document only the exported `isControllerCredential` API.

No changeset: documentation-only README fix with no runtime or API change.

## AI usage

Per [AI_POLICY.md](https://github.com/agentcommercekit/ack/blob/main/AI_POLICY.md), Cursor found these during a docs scan of main. I read the diff before opening this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated usage examples and API documentation to remove the deprecated `isControllerClaim` reference.
  * Corrected the A2A demo link.
  * Reformatted handshake examples for improved readability and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->