### PR TITLE
fix(ack-pay): bind payment receipt issuer to receiptService

### DIFF
--- a/packages/ack-pay/src/verify-payment-receipt.test.ts
+++ b/packages/ack-pay/src/verify-payment-receipt.test.ts
@@ -56,6 +56,7 @@ describe("verifyPaymentReceipt()", () => {
           currency: "USD",
           network: "eip155:84532",
           recipient: "0x592D4858DE40BC81A77E5B373238B70D7C79D3C79",
+          receiptService: receiptIssuerDid,
         },
       ],
     }
@@ -237,6 +238,31 @@ describe("verifyPaymentReceipt()", () => {
       verifyPaymentReceipt(signedReceiptJwt, {
         resolver,
         trustedReceiptIssuers: ["did:example:wrong-issuer"],
+      }),
+    ).rejects.toThrow(UntrustedIssuerError)
+  })
+
+  it("throws when the receipt issuer does not match the selected payment option receiptService", async () => {
+    const otherReceiptIssuerKeypair = await generateKeypair("secp256k1")
+    const otherReceiptIssuerDid = createDidKeyUri(otherReceiptIssuerKeypair)
+    const mismatchedReceipt = createPaymentReceipt({
+      paymentRequestToken,
+      paymentOptionId: "test-payment-option-id",
+      issuer: otherReceiptIssuerDid,
+      payerDid: createDidPkhUri(
+        "eip155:84532",
+        "0x7B3D8F2E1C9A4B5D6E7F8A9B0C1D2E3F4A5B6C",
+      ),
+    })
+    const signedMismatchedReceipt = await signCredential(mismatchedReceipt, {
+      did: otherReceiptIssuerDid,
+      signer: createJwtSigner(otherReceiptIssuerKeypair),
+    })
+
+    await expect(
+      verifyPaymentReceipt(signedMismatchedReceipt, {
+        resolver,
+        trustedReceiptIssuers: [receiptIssuerDid, otherReceiptIssuerDid],
       }),
     ).rejects.toThrow(UntrustedIssuerError)
   })

--- a/packages/ack-pay/src/verify-payment-receipt.ts
+++ b/packages/ack-pay/src/verify-payment-receipt.ts
@@ -1,10 +1,11 @@
-import type { Resolvable } from "@agentcommercekit/did"
+import { isDidUri, type Resolvable } from "@agentcommercekit/did"
 import { isJwtString, type JwtString } from "@agentcommercekit/jwt"
 import {
   InvalidCredentialError,
   InvalidCredentialSubjectError,
   isCredential,
   parseJwtCredential,
+  UntrustedIssuerError,
   verifyParsedCredential,
   type Verifiable,
   type W3CCredential,
@@ -127,6 +128,26 @@ export async function verifyPaymentReceipt(
       issuer: paymentRequestIssuer,
     },
   )
+
+  const selectedPaymentOption = paymentRequest.paymentOptions.find(
+    (paymentOption) =>
+      paymentOption.id === verifiedReceipt.credentialSubject.paymentOptionId,
+  )
+
+  if (!selectedPaymentOption) {
+    throw new InvalidCredentialSubjectError(
+      "Payment option ID was not found in the Payment Request",
+    )
+  }
+
+  if (
+    isDidUri(selectedPaymentOption.receiptService) &&
+    selectedPaymentOption.receiptService !== verifiedReceipt.issuer.id
+  ) {
+    throw new UntrustedIssuerError(
+      "Receipt issuer does not match the selected payment option receiptService",
+    )
+  }
 
   return {
     receipt: verifiedReceipt,


### PR DESCRIPTION
## Summary

Fixes #192

- Bind verified payment receipt issuers to the selected payment option `receiptService` when `receiptService` is a DID.
- Reject receipts whose `paymentOptionId` does not exist in the verified payment request.
- Add regression coverage for the cross-issuer case where both receipt issuers are globally trusted, but only one matches the selected option.

---

## Root Cause

`verifyPaymentReceipt` verified the receipt issuer against `trustedReceiptIssuers` and verified the embedded `paymentRequestToken`, but it did not compare the selected payment option's `receiptService` DID with the verified receipt issuer.

---

## What Changed

- Look up the selected payment option by `verifiedReceipt.credentialSubject.paymentOptionId`.
- Throw `InvalidCredentialSubjectError` when the payment option is missing.
- Throw `UntrustedIssuerError` when the selected payment option `receiptService` is a DID and does not match `verifiedReceipt.issuer.id`.

---

## Tests

- Added a regression test where two receipt issuers are globally trusted, but the receipt is signed by the wrong trusted issuer for the selected payment option.
- Confirmed the regression test fails without the production fix and passes with it.

---

## How to Test

```bash
pnpm --filter ./packages/ack-pay test -- --run src/verify-payment-receipt.test.ts
pnpm run format
pnpm run lint
pnpm --filter ./packages/ack-pay test
pnpm --filter ./packages/ack-pay build
```

---

## Checklist

- [x] Tests pass — new regression test added, confirmed fails without fix / passes with fix
- [x] Lint/format clean
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only

---

## Risk & Impact

**Low-to-medium.** The change only tightens verification: receipts whose `paymentOptionId` is missing or whose issuer doesn't match a DID-typed `receiptService` are now rejected. Payment options with a URL-typed `receiptService`, or a matching DID issuer, are unaffected — existing valid verification flows continue to pass.

**Type:** 🐛 Bug fix / 🔒 Security fix
**Fixes:** #192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Payment receipt verification now confirms that the receipt references a payment option included in the verified payment request.
  - Receipts are rejected when their issuer does not match the payment option’s declared receipt service, even if the issuer is otherwise trusted.
  - Added coverage for mismatched receipt issuers to help ensure invalid receipts cannot be accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->