### PR TITLE
demo(payments): add a cumulative spend budget to the policy guard

### DIFF
--- a/demos/payments/README.md
+++ b/demos/payments/README.md
@@ -20,7 +20,7 @@ This interactive command-line demo showcases a common use case: the **Server-Ini
   - Handling currency conversions.
   - Integrating compliance checks (KYC/AML).
   - Facilitating complex payment routing.
-  - Enforcing local payment policy before returning an execution URL or signing a receipt-service payload.
+  - Enforcing local payment policy, including a cumulative spend budget, before returning an execution URL or signing a receipt-service payload.
 
 You can learn more about the full ACK-Pay protocol at [www.agentcommercekit.com](https://www.agentcommercekit.com).
 
@@ -36,9 +36,10 @@ Payment Services should replace it with their own owner, risk, compliance, or
 human-approval system. The important safety boundary is that policy enforcement
 happens before execution or signing:
 
-- known low-value recipient: continue automatically
+- known low-value recipient, within budget: continue automatically
 - unknown recipient: return `approval_required`
-- amount above the illustrative per-transaction cap: deny before payment
+- amount above the per-transaction cap: deny before payment execution
+- amount that would exceed the rolling spend budget: deny before payment
   execution
 
 The per-currency cap is expressed in each currency's smallest subunit, so a
@@ -46,12 +47,40 @@ single flat threshold is never compared across currencies with different
 decimals (e.g. USD at 2dp vs USDC at 6dp). Currencies without a configured
 limit are denied outright.
 
+### Rolling spend budget
+
+A per-transaction cap on its own is not a spend control: it is trivially
+defeated by splitting one payment into many smaller ones (`cap × N`). The demo
+policy therefore also carries a cumulative budget over a rolling window,
+enforced against the small in-memory ledger in `src/spend-ledger.ts`.
+
+- `maxAutonomousAmount` bounds a single payment.
+- `budget.maxWindowAmount` bounds their sum over `budget.windowMs`, in the same
+  per-currency subunits.
+
+Two details are what make the budget hold rather than merely look right:
+
+- **The check and the reservation are one synchronous step.** The request
+  handler awaits token verification before policy runs, so a guard that read the
+  running total and then wrote to it would let two concurrent payments both
+  observe the pre-payment total and both pass. `SpendLedger.reserve` does both
+  at once.
+- **Reservations are keyed by payment attempt.** The Stripe path authorizes
+  twice for a single payment — once for the payment URL, once on the callback —
+  so reservations are keyed by payment request id plus payment option id. The
+  second authorization then re-checks the window without counting the payment
+  twice. A reservation is committed once the receipt is issued, and released if
+  signing or the Receipt Service call fails.
+
 > [!IMPORTANT]
-> The amount check is an **illustrative per-transaction cap, not a real spend
-> control.** A per-transaction limit is trivially defeated by splitting one
-> payment into many smaller ones (`cap × N`). A production policy needs a
-> cumulative and/or rate-limited budget (e.g. per-payer spend over a rolling
-> window), not just a single-transaction threshold.
+> This is still a demo, not production spend control. The ledger lives in
+> process memory, so it resets with the demo and is not shared between Payment
+> Service instances; a real budget needs durable storage and an atomic
+> check-and-reserve (a transactional `UPDATE ... WHERE`, or a distributed lock)
+> across every instance that can authorize payments. A real service would also
+> route a budget breach to human approval rather than denying outright, and
+> would key the budget on its authenticated payer — ACK-Pay carries no payer
+> identity on the payment execution request today.
 
 The demo allowlist is based on the configured server identity, not the issuer
 claimed by each incoming Payment Request token. A real Payment Service should

--- a/demos/payments/README.md
+++ b/demos/payments/README.md
@@ -70,7 +70,10 @@ Two details are what make the budget hold rather than merely look right:
   so reservations are keyed by payment request id plus payment option id. The
   second authorization then re-checks the window without counting the payment
   twice. A reservation is committed once the receipt is issued, and released if
-  signing or the Receipt Service call fails.
+  signing or the Receipt Service call fails. The Stripe callback only sets
+  `allowOverBudget` after consuming a pending settlement issued with the
+  payment URL (demo stand-in for verifying a signed Stripe event), and the
+  Receipt Service `fetch` uses a timeout so a hung call releases the reservation.
 
 > [!IMPORTANT]
 > This is still a demo, not production spend control. The ledger lives in

--- a/demos/payments/src/index.ts
+++ b/demos/payments/src/index.ts
@@ -58,6 +58,8 @@ import {
   solana,
   usdcAddress,
 } from "./constants"
+import { spendReference } from "./spend-ledger"
+import { signDemoStripeEvent } from "./stripe-settlement"
 import {
   ensureNonZeroBalances,
   ensureSolanaSolBalance,
@@ -217,6 +219,7 @@ The Client attempts to access a protected resource on the Server. Since no valid
         clientKeypairInfo,
         option,
         paymentRequestToken,
+        paymentRequest.id,
       )
     }
     if (option.network?.startsWith("solana:")) {
@@ -606,6 +609,7 @@ async function performStripePayment(
   _client: KeypairInfo,
   paymentOption: PaymentRequest["paymentOptions"][number],
   paymentRequestToken: JwtString,
+  paymentRequestId: string,
 ) {
   const paymentServiceUrl = paymentOption.paymentService
   if (!paymentServiceUrl) {
@@ -674,14 +678,18 @@ This flow is simulated in this example.
 
   await waitForEnter("Press Enter to simulate payment completion...")
 
-  // Step 2: Simulate the callback from Stripe with payment confirmation
+  // Step 2: Simulate the callback from Stripe with payment confirmation.
+  // The demo HMAC stands in for a real Stripe-Signature webhook check.
+  const eventId = "evt_" + Math.random().toString(36).substring(7)
+  const reference = spendReference(paymentRequestId, paymentOption.id)
   const response2 = await fetch(returnToUrl, {
     method: "POST",
     body: JSON.stringify({
       paymentOptionId: paymentOption.id,
       paymentRequestToken,
       metadata: {
-        eventId: "evt_" + Math.random().toString(36).substring(7), // Simulated Stripe event ID
+        eventId,
+        signature: signDemoStripeEvent(eventId, reference),
       },
     }),
   })

--- a/demos/payments/src/payment-policy.test.ts
+++ b/demos/payments/src/payment-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
-import { evaluatePaymentPolicy } from "./payment-policy"
+import { authorizePayment, evaluatePaymentPolicy } from "./payment-policy"
+import { createSpendLedger } from "./spend-ledger"
 
 const basePaymentOption = {
   id: "base-usdc",
@@ -158,5 +159,176 @@ describe("evaluatePaymentPolicy", () => {
       status: "denied",
       reason: "Payment amount must be a positive integer in subunits",
     })
+  })
+})
+
+describe("authorizePayment", () => {
+  const budgetPolicy = {
+    allowedRecipients: [basePaymentOption.recipient],
+    maxAutonomousAmount: { USDC: 1_000n },
+    budget: {
+      windowMs: 60_000,
+      maxWindowAmount: { USDC: 3_000n },
+    },
+  }
+
+  it("denies the split attack once the window budget is exhausted", () => {
+    const ledger = createSpendLedger()
+    const payment = { ...basePaymentOption, amount: 1_000 }
+
+    for (let i = 0; i < 3; i++) {
+      expect(
+        authorizePayment(payment, budgetPolicy, {
+          subject: "did:example:payer",
+          reference: `attempt-${i}`,
+          ledger,
+        }),
+      ).toEqual({ status: "approved" })
+    }
+
+    expect(
+      authorizePayment(payment, budgetPolicy, {
+        subject: "did:example:payer",
+        reference: "attempt-3",
+        ledger,
+      }),
+    ).toEqual({
+      status: "denied",
+      reason:
+        "Payment exceeds the autonomous spend budget for the current window",
+    })
+  })
+
+  it("does not consume budget for denied or approval-required payments", () => {
+    const ledger = createSpendLedger()
+
+    expect(
+      authorizePayment(
+        { ...basePaymentOption, amount: 10_000 },
+        budgetPolicy,
+        {
+          subject: "did:example:payer",
+          reference: "too-large",
+          ledger,
+        },
+      ).status,
+    ).toBe("denied")
+
+    expect(
+      authorizePayment(
+        basePaymentOption,
+        { ...budgetPolicy, allowedRecipients: [] },
+        {
+          subject: "did:example:payer",
+          reference: "unknown-recipient",
+          ledger,
+        },
+      ).status,
+    ).toBe("approval_required")
+
+    expect(ledger.spentWithin("did:example:payer", "USDC", 60_000)).toBe(0n)
+  })
+
+  it("re-authorizes the same reference without double-counting", () => {
+    const ledger = createSpendLedger()
+    const payment = { ...basePaymentOption, amount: 1_000 }
+    const auth = {
+      subject: "did:example:payer",
+      reference: "stripe-attempt",
+      ledger,
+    }
+
+    expect(authorizePayment(payment, budgetPolicy, auth)).toEqual({
+      status: "approved",
+    })
+    expect(authorizePayment(payment, budgetPolicy, auth)).toEqual({
+      status: "approved",
+    })
+    expect(ledger.spentWithin("did:example:payer", "USDC", 60_000)).toBe(
+      1_000n,
+    )
+  })
+
+  it("isolates subjects and currencies", () => {
+    const ledger = createSpendLedger()
+    const payment = { ...basePaymentOption, amount: 1_000 }
+
+    for (let i = 0; i < 3; i++) {
+      authorizePayment(payment, budgetPolicy, {
+        subject: "did:example:payer-a",
+        reference: `a-${i}`,
+        ledger,
+      })
+    }
+
+    expect(
+      authorizePayment(payment, budgetPolicy, {
+        subject: "did:example:payer-b",
+        reference: "b-0",
+        ledger,
+      }),
+    ).toEqual({ status: "approved" })
+
+    expect(
+      authorizePayment(
+        { ...payment, currency: "USD", decimals: 2, amount: 500 },
+        {
+          ...budgetPolicy,
+          maxAutonomousAmount: { USDC: 1_000n, USD: 500n },
+          budget: {
+            windowMs: 60_000,
+            maxWindowAmount: { USDC: 3_000n, USD: 2_000n },
+          },
+        },
+        {
+          subject: "did:example:payer-a",
+          reference: "usd-0",
+          ledger,
+        },
+      ),
+    ).toEqual({ status: "approved" })
+  })
+
+  it("expires spend out of the rolling window", () => {
+    let now = 1_000_000
+    const ledger = createSpendLedger({ now: () => now })
+    const payment = { ...basePaymentOption, amount: 1_000 }
+
+    for (let i = 0; i < 3; i++) {
+      authorizePayment(payment, budgetPolicy, {
+        subject: "did:example:payer",
+        reference: `old-${i}`,
+        ledger,
+      })
+    }
+
+    now += 60_001
+
+    expect(
+      authorizePayment(payment, budgetPolicy, {
+        subject: "did:example:payer",
+        reference: "after-expiry",
+        ledger,
+      }),
+    ).toEqual({ status: "approved" })
+  })
+
+  it("skips the window check when no budget is configured", () => {
+    const ledger = createSpendLedger()
+    const decision = authorizePayment(
+      basePaymentOption,
+      {
+        allowedRecipients: [basePaymentOption.recipient],
+        maxAutonomousAmount: { USDC: 1_000n },
+      },
+      {
+        subject: "did:example:payer",
+        reference: "no-budget",
+        ledger,
+      },
+    )
+
+    expect(decision).toEqual({ status: "approved" })
+    expect(ledger.spentWithin("did:example:payer", "USDC", 60_000)).toBe(0n)
   })
 })

--- a/demos/payments/src/payment-policy.test.ts
+++ b/demos/payments/src/payment-policy.test.ts
@@ -331,4 +331,44 @@ describe("authorizePayment", () => {
     expect(decision).toEqual({ status: "approved" })
     expect(ledger.spentWithin("did:example:payer", "USDC", 60_000)).toBe(0n)
   })
+
+  it("records and approves an over-budget payment when allowOverBudget is set", () => {
+    const ledger = createSpendLedger()
+    const payment = { ...basePaymentOption, amount: 1_000 }
+
+    for (let i = 0; i < 3; i++) {
+      expect(
+        authorizePayment(payment, budgetPolicy, {
+          subject: "did:example:payer",
+          reference: `fill-${i}`,
+          ledger,
+        }),
+      ).toEqual({ status: "approved" })
+    }
+
+    expect(
+      authorizePayment(payment, budgetPolicy, {
+        subject: "did:example:payer",
+        reference: "settled-callback",
+        ledger,
+      }),
+    ).toEqual({
+      status: "denied",
+      reason:
+        "Payment exceeds the autonomous spend budget for the current window",
+    })
+
+    expect(
+      authorizePayment(payment, budgetPolicy, {
+        subject: "did:example:payer",
+        reference: "settled-callback",
+        ledger,
+        allowOverBudget: true,
+      }),
+    ).toEqual({ status: "approved" })
+
+    expect(ledger.spentWithin("did:example:payer", "USDC", 60_000)).toBe(
+      4_000n,
+    )
+  })
 })

--- a/demos/payments/src/payment-policy.ts
+++ b/demos/payments/src/payment-policy.ts
@@ -161,6 +161,13 @@ export interface SpendAuthorization {
    */
   reference: string
   ledger: SpendLedger
+  /**
+   * When true, a rolling-window budget breach still records the spend and
+   * returns approved. Use on the Stripe callback after the payer has already
+   * been charged — withholding the receipt would leave them paying with no
+   * proof of settlement.
+   */
+  allowOverBudget?: boolean
 }
 
 /**
@@ -219,6 +226,18 @@ export function authorizePayment(
   })
 
   if (result.status === "exceeded") {
+    if (authorization.allowOverBudget) {
+      authorization.ledger.recordOverBudget({
+        reference: authorization.reference,
+        subject: authorization.subject,
+        currency: paymentOption.currency,
+        amount,
+        windowMs: policy.budget.windowMs,
+      })
+      return {
+        status: "approved",
+      }
+    }
     return {
       status: "denied",
       reason:

--- a/demos/payments/src/payment-policy.ts
+++ b/demos/payments/src/payment-policy.ts
@@ -1,5 +1,7 @@
 import type { PaymentOption } from "agentcommercekit"
 
+import type { SpendLedger } from "./spend-ledger"
+
 export type PaymentPolicyDecision =
   | {
       status: "approved"
@@ -8,6 +10,17 @@ export type PaymentPolicyDecision =
       status: "approval_required" | "denied"
       reason: string
     }
+
+interface SpendBudget {
+  /** Length of the rolling window, in milliseconds. */
+  windowMs: number
+  /**
+   * Cumulative spend allowed inside the window, in each currency's smallest
+   * subunit and keyed by currency code, following the same per-currency shape
+   * as `maxAutonomousAmount`. A currency with no configured budget is denied.
+   */
+  maxWindowAmount: Readonly<Record<string, bigint>>
+}
 
 export interface PaymentPolicy {
   allowedRecipients: readonly string[]
@@ -18,12 +31,20 @@ export interface PaymentPolicy {
    * threshold across currencies with different decimals (e.g. USD at 2dp vs
    * USDC at 6dp). A currency with no configured limit is denied.
    *
-   * NOTE: this is a per-transaction cap only, not a cumulative or rate budget.
-   * See the demo README — a real spend control needs windowed/cumulative
-   * limits, since a per-transaction cap is trivially split-gameable.
+   * This bounds a single payment only. `budget` bounds their sum, which is
+   * what stops one payment being split into many below-cap ones.
    */
   maxAutonomousAmount: Readonly<Record<string, bigint>>
+  /**
+   * Optional cumulative budget over a rolling window, enforced by
+   * `authorizePayment` against a `SpendLedger`. When omitted, only the
+   * per-transaction cap above applies.
+   */
+  budget?: SpendBudget
 }
+
+/** Rolling window the demo budget is measured over. */
+const DEMO_SPEND_WINDOW_MS = 60 * 60 * 1000
 
 export const demoPaymentPolicy: PaymentPolicy = {
   allowedRecipients: [],
@@ -32,19 +53,54 @@ export const demoPaymentPolicy: PaymentPolicy = {
     USD: 500n,
     USDC: 5_000_000n,
   },
+  budget: {
+    windowMs: DEMO_SPEND_WINDOW_MS,
+    maxWindowAmount: {
+      // 20.00 in each currency: four payments at the per-transaction cap,
+      // rather than an unbounded number of them.
+      USD: 2_000n,
+      USDC: 20_000_000n,
+    },
+  },
+}
+
+/**
+ * Follows the repo-wide BigInt money convention (see receipt-service.ts,
+ * index.ts). `BigInt()` throws on fractional/malformed amounts the ACK-Pay
+ * schema's string branch otherwise permits.
+ */
+function parseSubunitAmount(amount: PaymentOption["amount"]): bigint | null {
+  try {
+    return BigInt(amount)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * `currency` is an unconstrained wire string, so guard against inherited
+ * prototype keys (e.g. "constructor", "toString") that would otherwise resolve
+ * to a non-bigint value and slip past a comparison.
+ */
+function currencyLimit(
+  limits: Readonly<Record<string, bigint>>,
+  currency: string,
+): bigint | null {
+  if (!Object.prototype.hasOwnProperty.call(limits, currency)) {
+    return null
+  }
+
+  const limit = limits[currency]
+  return typeof limit === "bigint" ? limit : null
 }
 
 export function evaluatePaymentPolicy(
   paymentOption: PaymentOption,
   policy: PaymentPolicy = demoPaymentPolicy,
 ): PaymentPolicyDecision {
-  let amount: bigint
-  try {
-    // Follows the repo-wide BigInt money convention (see receipt-service.ts,
-    // index.ts). `BigInt()` throws on fractional/malformed amounts the
-    // ACK-Pay schema's string branch otherwise permits.
-    amount = BigInt(paymentOption.amount)
-  } catch {
+  const amount = parseSubunitAmount(paymentOption.amount)
+
+  if (amount === null) {
     return {
       status: "denied",
       reason: "Payment amount must be a positive integer in subunits",
@@ -58,16 +114,12 @@ export function evaluatePaymentPolicy(
     }
   }
 
-  // `currency` is an unconstrained wire string, so guard against inherited
-  // prototype keys (e.g. "constructor", "toString") that would otherwise
-  // resolve to a non-bigint value and slip past the comparison below.
-  const limit = Object.prototype.hasOwnProperty.call(
+  const limit = currencyLimit(
     policy.maxAutonomousAmount,
     paymentOption.currency,
   )
-    ? policy.maxAutonomousAmount[paymentOption.currency]
-    : undefined
-  if (typeof limit !== "bigint") {
+
+  if (limit === null) {
     return {
       status: "denied",
       reason: `No autonomous spend limit configured for currency ${paymentOption.currency}`,
@@ -85,6 +137,92 @@ export function evaluatePaymentPolicy(
     return {
       status: "approval_required",
       reason: "Recipient is not on the autonomous payment allowlist",
+    }
+  }
+
+  return {
+    status: "approved",
+  }
+}
+
+export interface SpendAuthorization {
+  /**
+   * The party the budget is tracked against: the payer this Payment Service
+   * spends on behalf of. The demo has a single autonomous payer, so this is
+   * the Payment Service's own DID. A multi-tenant service would key the budget
+   * on its authenticated payer instead — ACK-Pay does not carry a payer
+   * identity on the payment execution request today.
+   */
+  subject: string
+  /**
+   * Stable identifier for one payment attempt, so the two calls of the Stripe
+   * flow (payment URL, then callback) reserve once rather than twice. See
+   * `spendReference`.
+   */
+  reference: string
+  ledger: SpendLedger
+}
+
+/**
+ * Applies the full policy to a payment before it is executed or signed: the
+ * per-transaction checks in `evaluatePaymentPolicy`, then the cumulative
+ * rolling-window budget when the policy configures one.
+ *
+ * An approved decision has reserved the amount against the window. The caller
+ * must `commit` the reservation once the payment settles, or `release` it if
+ * execution fails.
+ *
+ * @param paymentOption - The verified payment option about to be executed
+ * @param policy - The policy to apply
+ * @param authorization - Budget subject, attempt reference, and ledger
+ * @returns The policy decision
+ */
+export function authorizePayment(
+  paymentOption: PaymentOption,
+  policy: PaymentPolicy,
+  authorization: SpendAuthorization,
+): PaymentPolicyDecision {
+  const decision = evaluatePaymentPolicy(paymentOption, policy)
+
+  if (decision.status !== "approved" || !policy.budget) {
+    return decision
+  }
+
+  const amount = parseSubunitAmount(paymentOption.amount)
+  if (amount === null) {
+    // Unreachable: `evaluatePaymentPolicy` already denied unparseable amounts.
+    return {
+      status: "denied",
+      reason: "Payment amount must be a positive integer in subunits",
+    }
+  }
+
+  const limit = currencyLimit(
+    policy.budget.maxWindowAmount,
+    paymentOption.currency,
+  )
+
+  if (limit === null) {
+    return {
+      status: "denied",
+      reason: `No autonomous spend budget configured for currency ${paymentOption.currency}`,
+    }
+  }
+
+  const result = authorization.ledger.reserve({
+    reference: authorization.reference,
+    subject: authorization.subject,
+    currency: paymentOption.currency,
+    amount,
+    windowMs: policy.budget.windowMs,
+    limit,
+  })
+
+  if (result.status === "exceeded") {
+    return {
+      status: "denied",
+      reason:
+        "Payment exceeds the autonomous spend budget for the current window",
     }
   }
 

--- a/demos/payments/src/payment-service.ts
+++ b/demos/payments/src/payment-service.ts
@@ -102,11 +102,14 @@ app.post(
     }
 
     // Re-authorizing under the same payment-attempt reference re-checks the
-    // window without counting this payment a second time.
+    // window without counting this payment a second time. Stripe has already
+    // charged the payer by this point, so a rolling-window breach is recorded
+    // and receipt issuance continues rather than returning 403.
     const reference = spendReference(paymentRequest.id, paymentOptionId)
     await enforcePaymentPolicy(c, paymentOption, {
       subject: payerIdentity.did,
       reference,
+      allowOverBudget: true,
     })
 
     const payload = {
@@ -186,7 +189,11 @@ async function enforcePaymentPolicy(
   paymentOption: Awaited<
     ReturnType<typeof validatePaymentOption>
   >["paymentOption"],
-  { subject, reference }: { subject: DidUri; reference: string },
+  {
+    subject,
+    reference,
+    allowOverBudget,
+  }: { subject: DidUri; reference: string; allowOverBudget?: boolean },
 ) {
   const decision = authorizePayment(
     paymentOption,
@@ -198,6 +205,7 @@ async function enforcePaymentPolicy(
       subject,
       reference,
       ledger: spendLedger,
+      allowOverBudget,
     },
   )
 

--- a/demos/payments/src/payment-service.ts
+++ b/demos/payments/src/payment-service.ts
@@ -58,20 +58,27 @@ app.post("/", async (c): Promise<TypedResponse<{ paymentUrl: string }>> => {
     paymentRequestToken,
   )
   const payerIdentity = await getPayerIdentity(c)
+  const reference = spendReference(paymentRequest.id, paymentOptionId)
   await enforcePaymentPolicy(c, paymentOption, {
     subject: payerIdentity.did,
-    reference: spendReference(paymentRequest.id, paymentOptionId),
+    reference,
   })
 
-  log(colors.dim(`${name} Generating Stripe payment URL ...`))
+  try {
+    log(colors.dim(`${name} Generating Stripe payment URL ...`))
 
-  // This is a placeholder for an actual Strip Payment URL which would
-  // have webhook callbacks already set up
-  const paymentUrl = `https://payments.stripe.com/payment-url/?return_to=${PAYMENT_SERVICE_URL}/stripe-callback`
+    // This is a placeholder for an actual Strip Payment URL which would
+    // have webhook callbacks already set up
+    const paymentUrl = `https://payments.stripe.com/payment-url/?return_to=${PAYMENT_SERVICE_URL}/stripe-callback`
 
-  return c.json({
-    paymentUrl,
-  })
+    return c.json({
+      paymentUrl,
+    })
+  } catch (error) {
+    // No payment was started, so it must not hold the window budget.
+    spendLedger.release(reference)
+    throw error
+  }
 })
 
 const callbackSchema = v.object({

--- a/demos/payments/src/payment-service.ts
+++ b/demos/payments/src/payment-service.ts
@@ -17,6 +17,10 @@ import * as v from "valibot"
 import { PAYMENT_SERVICE_URL } from "./constants"
 import { authorizePayment, demoPaymentPolicy } from "./payment-policy"
 import { createSpendLedger, spendReference } from "./spend-ledger"
+import {
+  createStripeSettlementTracker,
+  fetchWithTimeout,
+} from "./stripe-settlement"
 import { getKeypairInfo } from "./utils/keypair-info"
 
 const app = new Hono<Env>()
@@ -27,6 +31,13 @@ app.use(logger())
  * policy's rolling window. In-memory, so it resets with the demo process.
  */
 const spendLedger = createSpendLedger()
+
+/**
+ * Demo stand-in for Stripe settlement verification. Payment URLs register a
+ * pending attempt; the callback may only set `allowOverBudget` after that
+ * attempt is consumed with a Stripe-shaped event id.
+ */
+const stripeSettlements = createStripeSettlementTracker()
 
 const bodySchema = v.object({
   paymentOptionId: v.string(),
@@ -67,6 +78,13 @@ app.post("/", async (c): Promise<TypedResponse<{ paymentUrl: string }>> => {
   try {
     log(colors.dim(`${name} Generating Stripe payment URL ...`))
 
+    // Register the attempt before returning the URL so the later callback can
+    // prove this payment was initiated here (demo stand-in for Stripe Events).
+    stripeSettlements.issue(reference, {
+      paymentRequestId: paymentRequest.id,
+      paymentOptionId,
+    })
+
     // This is a placeholder for an actual Strip Payment URL which would
     // have webhook callbacks already set up
     const paymentUrl = `https://payments.stripe.com/payment-url/?return_to=${PAYMENT_SERVICE_URL}/stripe-callback`
@@ -77,6 +95,7 @@ app.post("/", async (c): Promise<TypedResponse<{ paymentUrl: string }>> => {
   } catch (error) {
     // No payment was started, so it must not hold the window budget.
     spendLedger.release(reference)
+    stripeSettlements.release(reference)
     throw error
   }
 })
@@ -108,11 +127,29 @@ app.post(
       throw new Error(errorMessage("Receipt service URL is required"))
     }
 
-    // Re-authorizing under the same payment-attempt reference re-checks the
-    // window without counting this payment a second time. Stripe has already
-    // charged the payer by this point, so a rolling-window breach is recorded
-    // and receipt issuance continues rather than returning 403.
+    // Only treat the charge as settled (and allow over-budget receipting)
+    // after verifying this attempt was issued a payment URL and carries a
+    // Stripe-shaped event id. A real service would validate a signed webhook.
     const reference = spendReference(paymentRequest.id, paymentOptionId)
+    const settlement = stripeSettlements.consumeVerified(
+      reference,
+      metadata.eventId,
+      {
+        paymentRequestId: paymentRequest.id,
+        paymentOptionId,
+      },
+    )
+    if (!settlement.ok) {
+      log(errorMessage(`${name} ${settlement.reason}`))
+      throw new HTTPException(401, {
+        message: settlement.reason,
+      })
+    }
+
+    // Re-authorizing under the same payment-attempt reference re-checks the
+    // window without counting this payment a second time. Settlement is
+    // verified above, so a rolling-window breach is recorded and receipt
+    // issuance continues rather than returning 403.
     await enforcePaymentPolicy(c, paymentOption, {
       subject: payerIdentity.did,
       reference,
@@ -138,7 +175,7 @@ app.post(
         signer: payerIdentity.jwtSigner,
       })
 
-      const response = await fetch(receiptServiceUrl, {
+      const response = await fetchWithTimeout(receiptServiceUrl, {
         method: "POST",
         body: JSON.stringify({
           payload: signedPayload,

--- a/demos/payments/src/payment-service.ts
+++ b/demos/payments/src/payment-service.ts
@@ -5,6 +5,7 @@ import {
   createJwt,
   getDidResolver,
   verifyPaymentRequestToken,
+  type DidUri,
   type JwtString,
 } from "agentcommercekit"
 import { jwtStringSchema } from "agentcommercekit/schemas/valibot"
@@ -14,11 +15,18 @@ import { HTTPException } from "hono/http-exception"
 import * as v from "valibot"
 
 import { PAYMENT_SERVICE_URL } from "./constants"
-import { demoPaymentPolicy, evaluatePaymentPolicy } from "./payment-policy"
+import { authorizePayment, demoPaymentPolicy } from "./payment-policy"
+import { createSpendLedger, spendReference } from "./spend-ledger"
 import { getKeypairInfo } from "./utils/keypair-info"
 
 const app = new Hono<Env>()
 app.use(logger())
+
+/**
+ * Tracks how much this Payment Service has already authorized inside the
+ * policy's rolling window. In-memory, so it resets with the demo process.
+ */
+const spendLedger = createSpendLedger()
 
 const bodySchema = v.object({
   paymentOptionId: v.string(),
@@ -45,11 +53,15 @@ app.post("/", async (c): Promise<TypedResponse<{ paymentUrl: string }>> => {
 
   // Verify the payment request token and payment option are valid before
   // returning an execution URL.
-  const { paymentOption } = await validatePaymentOption(
+  const { paymentRequest, paymentOption } = await validatePaymentOption(
     paymentOptionId,
     paymentRequestToken,
   )
-  enforcePaymentPolicy(paymentOption, await getTrustedRecipients(c))
+  const payerIdentity = await getPayerIdentity(c)
+  await enforcePaymentPolicy(c, paymentOption, {
+    subject: payerIdentity.did,
+    reference: spendReference(paymentRequest.id, paymentOptionId),
+  })
 
   log(colors.dim(`${name} Generating Stripe payment URL ...`))
 
@@ -72,9 +84,7 @@ const callbackSchema = v.object({
 app.post(
   "/stripe-callback",
   async (c): Promise<TypedResponse<{ receipt: string }>> => {
-    const serverIdentity = await getKeypairInfo(
-      env(c).PAYMENT_SERVICE_PRIVATE_KEY_HEX,
-    )
+    const payerIdentity = await getPayerIdentity(c)
 
     const { paymentOptionId, paymentRequestToken, metadata } = v.parse(
       callbackSchema,
@@ -82,7 +92,7 @@ app.post(
     )
 
     // Verify the payment request token and payment option are valid
-    const { paymentOption } = await validatePaymentOption(
+    const { paymentRequest, paymentOption } = await validatePaymentOption(
       paymentOptionId,
       paymentRequestToken,
     )
@@ -90,7 +100,14 @@ app.post(
     if (!receiptServiceUrl) {
       throw new Error(errorMessage("Receipt service URL is required"))
     }
-    enforcePaymentPolicy(paymentOption, await getTrustedRecipients(c))
+
+    // Re-authorizing under the same payment-attempt reference re-checks the
+    // window without counting this payment a second time.
+    const reference = spendReference(paymentRequest.id, paymentOptionId)
+    await enforcePaymentPolicy(c, paymentOption, {
+      subject: payerIdentity.did,
+      reference,
+    })
 
     const payload = {
       paymentRequestToken,
@@ -99,31 +116,36 @@ app.post(
         network: "stripe",
         eventId: metadata.eventId,
       },
-      payerDid: serverIdentity.did,
+      payerDid: payerIdentity.did,
     }
 
-    const signedPayload = await createJwt(payload, {
-      issuer: serverIdentity.did,
-      signer: serverIdentity.jwtSigner,
-    })
-
     log(colors.dim(`${name} Getting receipt from Receipt Service...`))
-    const response = await fetch(receiptServiceUrl, {
-      method: "POST",
-      body: JSON.stringify({
-        payload: signedPayload,
-      }),
-    })
 
-    const { receipt, details } = v.parse(
-      receiptResponseSchema,
-      await response.json(),
-    )
+    let receiptResponse: v.InferOutput<typeof receiptResponseSchema>
+    try {
+      const signedPayload = await createJwt(payload, {
+        issuer: payerIdentity.did,
+        signer: payerIdentity.jwtSigner,
+      })
 
-    return c.json({
-      receipt,
-      details,
-    })
+      const response = await fetch(receiptServiceUrl, {
+        method: "POST",
+        body: JSON.stringify({
+          payload: signedPayload,
+        }),
+      })
+
+      receiptResponse = v.parse(receiptResponseSchema, await response.json())
+    } catch (error) {
+      // The payment never produced a receipt, so it should not keep consuming
+      // the window budget.
+      spendLedger.release(reference)
+      throw error
+    }
+
+    spendLedger.commit(reference)
+
+    return c.json(receiptResponse)
   },
 )
 
@@ -159,16 +181,25 @@ async function validatePaymentOption(
   }
 }
 
-function enforcePaymentPolicy(
+async function enforcePaymentPolicy(
+  c: Context<Env>,
   paymentOption: Awaited<
     ReturnType<typeof validatePaymentOption>
   >["paymentOption"],
-  allowedRecipients: readonly string[],
+  { subject, reference }: { subject: DidUri; reference: string },
 ) {
-  const decision = evaluatePaymentPolicy(paymentOption, {
-    ...demoPaymentPolicy,
-    allowedRecipients,
-  })
+  const decision = authorizePayment(
+    paymentOption,
+    {
+      ...demoPaymentPolicy,
+      allowedRecipients: await getTrustedRecipients(c),
+    },
+    {
+      subject,
+      reference,
+      ledger: spendLedger,
+    },
+  )
 
   if (decision.status !== "approved") {
     log(errorMessage(`${name} ${decision.reason}`))
@@ -176,6 +207,15 @@ function enforcePaymentPolicy(
       message: decision.reason,
     })
   }
+}
+
+/**
+ * The identity this Payment Service signs and spends as. The demo has a single
+ * autonomous payer, so it is also the subject the spend budget is tracked
+ * against.
+ */
+function getPayerIdentity(c: Context<Env>) {
+  return getKeypairInfo(env(c).PAYMENT_SERVICE_PRIVATE_KEY_HEX)
 }
 
 async function getTrustedRecipients(c: Context<Env>) {

--- a/demos/payments/src/payment-service.ts
+++ b/demos/payments/src/payment-service.ts
@@ -35,7 +35,7 @@ const spendLedger = createSpendLedger()
 /**
  * Demo stand-in for Stripe settlement verification. Payment URLs register a
  * pending attempt; the callback may only set `allowOverBudget` after that
- * attempt is consumed with a Stripe-shaped event id.
+ * attempt is verified with a Stripe-shaped event id and HMAC signature.
  */
 const stripeSettlements = createStripeSettlementTracker()
 
@@ -104,6 +104,8 @@ const callbackSchema = v.object({
   ...bodySchema.entries,
   metadata: v.object({
     eventId: v.string(),
+    /** Demo HMAC (`eventId.reference`); production uses Stripe-Signature. */
+    signature: v.string(),
   }),
 })
 
@@ -128,12 +130,14 @@ app.post(
     }
 
     // Only treat the charge as settled (and allow over-budget receipting)
-    // after verifying this attempt was issued a payment URL and carries a
-    // Stripe-shaped event id. A real service would validate a signed webhook.
+    // after verifying this attempt was issued a payment URL and the Stripe
+    // event is authenticated with the demo webhook HMAC. Settlement state is
+    // retained until receipt issuance succeeds so retries remain possible.
     const reference = spendReference(paymentRequest.id, paymentOptionId)
-    const settlement = stripeSettlements.consumeVerified(
+    const settlement = stripeSettlements.verify(
       reference,
       metadata.eventId,
+      metadata.signature,
       {
         paymentRequestId: paymentRequest.id,
         paymentOptionId,
@@ -185,12 +189,13 @@ app.post(
       receiptResponse = v.parse(receiptResponseSchema, await response.json())
     } catch (error) {
       // The payment never produced a receipt, so it should not keep consuming
-      // the window budget.
+      // the window budget. Settlement stays verified for an idempotent retry.
       spendLedger.release(reference)
       throw error
     }
 
     spendLedger.commit(reference)
+    stripeSettlements.commit(reference)
 
     return c.json(receiptResponse)
   },

--- a/demos/payments/src/spend-ledger.test.ts
+++ b/demos/payments/src/spend-ledger.test.ts
@@ -160,4 +160,40 @@ describe("createSpendLedger", () => {
       }).status,
     ).toBe("reserved")
   })
+
+  it("recordOverBudget keeps the spend even when the window is full", () => {
+    const ledger = createSpendLedger()
+
+    expect(
+      ledger.reserve({
+        reference: "first",
+        subject: "payer",
+        currency: "USDC",
+        amount: 200n,
+        windowMs: 60_000,
+        limit: 250n,
+      }).status,
+    ).toBe("reserved")
+
+    expect(
+      ledger.reserve({
+        reference: "second",
+        subject: "payer",
+        currency: "USDC",
+        amount: 200n,
+        windowMs: 60_000,
+        limit: 250n,
+      }).status,
+    ).toBe("exceeded")
+
+    ledger.recordOverBudget({
+      reference: "second",
+      subject: "payer",
+      currency: "USDC",
+      amount: 200n,
+      windowMs: 60_000,
+    })
+
+    expect(ledger.spentWithin("payer", "USDC", 60_000)).toBe(400n)
+  })
 })

--- a/demos/payments/src/spend-ledger.test.ts
+++ b/demos/payments/src/spend-ledger.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest"
+
+import { createSpendLedger, spendReference } from "./spend-ledger"
+
+describe("spendReference", () => {
+  it("encodes request and option ids so colon-containing parts cannot collide", () => {
+    expect(spendReference("a:b", "c")).not.toBe(spendReference("a", "b:c"))
+  })
+})
+
+describe("createSpendLedger", () => {
+  it("reserves within the window and reports spent", () => {
+    const ledger = createSpendLedger()
+
+    expect(
+      ledger.reserve({
+        reference: "r1",
+        subject: "payer",
+        currency: "USDC",
+        amount: 100n,
+        windowMs: 60_000,
+        limit: 250n,
+      }),
+    ).toEqual({ status: "reserved", spent: 100n })
+
+    expect(ledger.spentWithin("payer", "USDC", 60_000)).toBe(100n)
+  })
+
+  it("rejects when the window budget would be exceeded", () => {
+    const ledger = createSpendLedger()
+
+    ledger.reserve({
+      reference: "r1",
+      subject: "payer",
+      currency: "USDC",
+      amount: 200n,
+      windowMs: 60_000,
+      limit: 250n,
+    })
+
+    expect(
+      ledger.reserve({
+        reference: "r2",
+        subject: "payer",
+        currency: "USDC",
+        amount: 100n,
+        windowMs: 60_000,
+        limit: 250n,
+      }),
+    ).toEqual({ status: "exceeded", spent: 200n, limit: 250n })
+  })
+
+  it("re-reserves the same reference without double-counting", () => {
+    const ledger = createSpendLedger()
+    const reservation = {
+      reference: "same",
+      subject: "payer",
+      currency: "USDC",
+      amount: 100n,
+      windowMs: 60_000,
+      limit: 250n,
+    }
+
+    expect(ledger.reserve(reservation)).toEqual({
+      status: "reserved",
+      spent: 100n,
+    })
+    expect(ledger.reserve(reservation)).toEqual({
+      status: "reserved",
+      spent: 100n,
+    })
+    expect(ledger.spentWithin("payer", "USDC", 60_000)).toBe(100n)
+  })
+
+  it("releases an unsettled reservation and ignores release after commit", () => {
+    const ledger = createSpendLedger()
+
+    ledger.reserve({
+      reference: "to-release",
+      subject: "payer",
+      currency: "USDC",
+      amount: 100n,
+      windowMs: 60_000,
+      limit: 250n,
+    })
+    ledger.release("to-release")
+    expect(ledger.spentWithin("payer", "USDC", 60_000)).toBe(0n)
+
+    ledger.reserve({
+      reference: "to-commit",
+      subject: "payer",
+      currency: "USDC",
+      amount: 100n,
+      windowMs: 60_000,
+      limit: 250n,
+    })
+    ledger.commit("to-commit")
+    ledger.release("to-commit")
+    expect(ledger.spentWithin("payer", "USDC", 60_000)).toBe(100n)
+  })
+
+  it("expires entries outside the rolling window", () => {
+    let now = 1_000_000
+    const ledger = createSpendLedger({ now: () => now })
+
+    ledger.reserve({
+      reference: "old",
+      subject: "payer",
+      currency: "USDC",
+      amount: 200n,
+      windowMs: 60_000,
+      limit: 250n,
+    })
+
+    now += 60_001
+
+    expect(
+      ledger.reserve({
+        reference: "new",
+        subject: "payer",
+        currency: "USDC",
+        amount: 200n,
+        windowMs: 60_000,
+        limit: 250n,
+      }),
+    ).toEqual({ status: "reserved", spent: 200n })
+  })
+
+  it("isolates subjects and currencies", () => {
+    const ledger = createSpendLedger()
+
+    ledger.reserve({
+      reference: "a",
+      subject: "payer-a",
+      currency: "USDC",
+      amount: 200n,
+      windowMs: 60_000,
+      limit: 250n,
+    })
+
+    expect(
+      ledger.reserve({
+        reference: "b",
+        subject: "payer-b",
+        currency: "USDC",
+        amount: 200n,
+        windowMs: 60_000,
+        limit: 250n,
+      }).status,
+    ).toBe("reserved")
+
+    expect(
+      ledger.reserve({
+        reference: "c",
+        subject: "payer-a",
+        currency: "USD",
+        amount: 200n,
+        windowMs: 60_000,
+        limit: 250n,
+      }).status,
+    ).toBe("reserved")
+  })
+})

--- a/demos/payments/src/spend-ledger.ts
+++ b/demos/payments/src/spend-ledger.ts
@@ -64,6 +64,12 @@ export interface SpendLedger {
    * payments would both observe the pre-payment total and both pass.
    */
   reserve(reservation: SpendReservation): SpendReservationResult
+  /**
+   * Records a reservation even when it exceeds the window limit. Used by the
+   * Stripe callback after the payer has already been charged: the overspend is
+   * an accounting fact to keep, not a reason to withhold the receipt.
+   */
+  recordOverBudget(reservation: Omit<SpendReservation, "limit">): void
   /** Marks a reservation as settled, so it can no longer be released. */
   commit(reference: string): void
   /** Drops an unsettled reservation, e.g. when execution failed. */
@@ -168,6 +174,24 @@ export function createSpendLedger({
       })
 
       return { status: "reserved", spent: spent + amount }
+    },
+
+    recordOverBudget({ reference, subject, currency, amount, windowMs }) {
+      const cutoff = now() - windowMs
+      for (const [key, entry] of entries) {
+        if (entry.at <= cutoff) {
+          entries.delete(key)
+        }
+      }
+
+      const existing = entries.get(reference)
+      entries.set(reference, {
+        subject,
+        currency,
+        amount,
+        at: existing?.at ?? now(),
+        committed: existing?.committed ?? false,
+      })
     },
 
     commit(reference) {

--- a/demos/payments/src/spend-ledger.ts
+++ b/demos/payments/src/spend-ledger.ts
@@ -1,0 +1,191 @@
+/**
+ * A tiny in-memory spend ledger for the payments demo.
+ *
+ * The ledger records how much a subject (the party a Payment Service spends on
+ * behalf of) has already put at risk inside a rolling time window, so policy
+ * can enforce a cumulative budget instead of only a per-transaction cap. A
+ * per-transaction cap on its own is trivially defeated by splitting one payment
+ * into many smaller ones.
+ *
+ * This is a demo store, not a spend control. It lives in process memory, so it
+ * resets on restart and is not shared between Payment Service instances. A
+ * production budget needs durable storage and an atomic check-and-reserve
+ * (a transactional `UPDATE ... WHERE` or a distributed lock) whenever more than
+ * one instance can authorize payments.
+ */
+
+interface SpendLedgerEntry {
+  subject: string
+  currency: string
+  /** Amount in the currency's smallest subunit. */
+  amount: bigint
+  /** Epoch milliseconds at which the amount was reserved. */
+  at: number
+  /** `true` once the payment this entry covers has actually settled. */
+  committed: boolean
+}
+
+interface SpendReservation {
+  /**
+   * Stable identifier for a single payment attempt. Reserving the same
+   * reference twice replaces the existing entry rather than adding a second
+   * one, so the two-phase Stripe flow (payment URL, then callback) and any
+   * retries never count one payment twice.
+   */
+  reference: string
+  subject: string
+  currency: string
+  /** Amount in the currency's smallest subunit. */
+  amount: bigint
+  /** Length of the rolling window, in milliseconds. */
+  windowMs: number
+  /** Cumulative cap for this subject and currency across the window. */
+  limit: bigint
+}
+
+type SpendReservationResult =
+  | {
+      status: "reserved"
+      /** Window total for this subject and currency, including this reservation. */
+      spent: bigint
+    }
+  | {
+      status: "exceeded"
+      /** Window total excluding the rejected reservation. */
+      spent: bigint
+      limit: bigint
+    }
+
+export interface SpendLedger {
+  /**
+   * Checks the rolling window and records the amount in a single synchronous
+   * step. Callers must not check the window and reserve separately: the
+   * enclosing request handler awaits before policy runs, so two concurrent
+   * payments would both observe the pre-payment total and both pass.
+   */
+  reserve(reservation: SpendReservation): SpendReservationResult
+  /** Marks a reservation as settled, so it can no longer be released. */
+  commit(reference: string): void
+  /** Drops an unsettled reservation, e.g. when execution failed. */
+  release(reference: string): void
+  /** Reserved and committed total for a subject and currency in the window. */
+  spentWithin(subject: string, currency: string, windowMs: number): bigint
+}
+
+export interface SpendLedgerOptions {
+  /** Clock override, for tests. */
+  now?: () => number
+}
+
+/**
+ * Builds the reservation key identifying one payment attempt, so both calls of
+ * the Stripe flow reserve against the same entry.
+ *
+ * The parts are unconstrained strings carried in the Payment Request, so they
+ * are encoded rather than concatenated: a plain `${a}:${b}` lets `("a:b", "c")`
+ * and `("a", "b:c")` collide, and a collision would silently overwrite an
+ * earlier reservation and drop its amount from the window.
+ *
+ * @param paymentRequestId - `id` of the verified Payment Request
+ * @param paymentOptionId - `id` of the selected payment option
+ * @returns A key unique to the pair
+ */
+export function spendReference(
+  paymentRequestId: string,
+  paymentOptionId: string,
+): string {
+  return JSON.stringify([paymentRequestId, paymentOptionId])
+}
+
+/**
+ * Creates an in-memory spend ledger.
+ *
+ * All calls are expected to share one window length (the one configured on the
+ * policy). `reserve` discards entries that have aged out of the window it is
+ * given, which is what bounds the ledger's memory.
+ *
+ * @param options - Optional clock override
+ * @returns A `SpendLedger`
+ */
+export function createSpendLedger({
+  now = () => Date.now(),
+}: SpendLedgerOptions = {}): SpendLedger {
+  const entries = new Map<string, SpendLedgerEntry>()
+
+  function totalWithin(
+    subject: string,
+    currency: string,
+    windowMs: number,
+    excludeReference?: string,
+  ): bigint {
+    const cutoff = now() - windowMs
+    let total = 0n
+
+    for (const [reference, entry] of entries) {
+      if (reference === excludeReference) {
+        continue
+      }
+      if (entry.subject !== subject || entry.currency !== currency) {
+        continue
+      }
+      if (entry.at <= cutoff) {
+        continue
+      }
+      total += entry.amount
+    }
+
+    return total
+  }
+
+  return {
+    reserve({ reference, subject, currency, amount, windowMs, limit }) {
+      const cutoff = now() - windowMs
+      for (const [key, entry] of entries) {
+        if (entry.at <= cutoff) {
+          entries.delete(key)
+        }
+      }
+
+      // Exclude any earlier reservation under this reference, otherwise the
+      // second phase of a single payment would be counted on top of its own
+      // first phase and denied.
+      const spent = totalWithin(subject, currency, windowMs, reference)
+
+      if (spent + amount > limit) {
+        return { status: "exceeded", spent, limit }
+      }
+
+      // Keep the original timestamp when re-reserving, so a payment ages out of
+      // the window from its first attempt and cannot be held open indefinitely.
+      const existing = entries.get(reference)
+
+      entries.set(reference, {
+        subject,
+        currency,
+        amount,
+        at: existing?.at ?? now(),
+        committed: existing?.committed ?? false,
+      })
+
+      return { status: "reserved", spent: spent + amount }
+    },
+
+    commit(reference) {
+      const entry = entries.get(reference)
+      if (entry) {
+        entry.committed = true
+      }
+    },
+
+    release(reference) {
+      const entry = entries.get(reference)
+      if (entry && !entry.committed) {
+        entries.delete(reference)
+      }
+    },
+
+    spentWithin(subject, currency, windowMs) {
+      return totalWithin(subject, currency, windowMs)
+    },
+  }
+}

--- a/demos/payments/src/stripe-settlement.test.ts
+++ b/demos/payments/src/stripe-settlement.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import {
+  RECEIPT_FETCH_TIMEOUT_MS,
+  createStripeSettlementTracker,
+  fetchWithTimeout,
+  isDemoStripeEventId,
+} from "./stripe-settlement"
+
+describe("isDemoStripeEventId", () => {
+  it("accepts Stripe-shaped event ids", () => {
+    expect(isDemoStripeEventId("evt_1Abc")).toBe(true)
+    expect(isDemoStripeEventId("evt_abc123XYZ")).toBe(true)
+  })
+
+  it("rejects empty or non-Stripe ids", () => {
+    expect(isDemoStripeEventId("")).toBe(false)
+    expect(isDemoStripeEventId("evt_")).toBe(false)
+    expect(isDemoStripeEventId("evt_abc-def")).toBe(false)
+    expect(isDemoStripeEventId("pi_123")).toBe(false)
+    expect(isDemoStripeEventId("forged")).toBe(false)
+  })
+})
+
+describe("createStripeSettlementTracker", () => {
+  const expected = {
+    paymentRequestId: "req_1",
+    paymentOptionId: "stripe-usd",
+  }
+
+  it("verifies only after a matching payment URL was issued", () => {
+    const tracker = createStripeSettlementTracker()
+    const reference = "req_1:stripe-usd"
+
+    expect(
+      tracker.consumeVerified(reference, "evt_abc", expected).ok,
+    ).toBe(false)
+
+    tracker.issue(reference, expected)
+    expect(
+      tracker.consumeVerified(reference, "evt_abc", expected),
+    ).toEqual({ ok: true })
+
+    // One-time: a second callback cannot reuse the same settlement.
+    expect(
+      tracker.consumeVerified(reference, "evt_abc", expected).ok,
+    ).toBe(false)
+  })
+
+  it("rejects mismatched payment request or option", () => {
+    const tracker = createStripeSettlementTracker()
+    const reference = "req_1:stripe-usd"
+    tracker.issue(reference, expected)
+
+    expect(
+      tracker.consumeVerified(reference, "evt_abc", {
+        paymentRequestId: "req_other",
+        paymentOptionId: "stripe-usd",
+      }).ok,
+    ).toBe(false)
+
+    expect(
+      tracker.consumeVerified(reference, "evt_abc", {
+        paymentRequestId: "req_1",
+        paymentOptionId: "other",
+      }).ok,
+    ).toBe(false)
+  })
+
+  it("rejects invalid event ids even when issued", () => {
+    const tracker = createStripeSettlementTracker()
+    const reference = "req_1:stripe-usd"
+    tracker.issue(reference, expected)
+
+    expect(tracker.consumeVerified(reference, "bad", expected).ok).toBe(false)
+    // Still pending after a bad event id — a valid callback can still succeed.
+    expect(
+      tracker.consumeVerified(reference, "evt_ok", expected),
+    ).toEqual({ ok: true })
+  })
+
+  it("release drops a pending settlement without verifying", () => {
+    const tracker = createStripeSettlementTracker()
+    const reference = "req_1:stripe-usd"
+    tracker.issue(reference, expected)
+    tracker.release(reference)
+    expect(
+      tracker.consumeVerified(reference, "evt_abc", expected).ok,
+    ).toBe(false)
+  })
+})
+
+describe("fetchWithTimeout", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it("passes AbortSignal to fetch", async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      expect(init?.signal).toBeInstanceOf(AbortSignal)
+      return new Response("{}", { status: 200 })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    await fetchWithTimeout("https://example.test/receipt", {
+      method: "POST",
+      body: "{}",
+    })
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+  })
+
+  it("aborts when the request exceeds the timeout", async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init?: RequestInit) => {
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"))
+          })
+        })
+      }),
+    )
+
+    const pending = fetchWithTimeout(
+      "https://example.test/receipt",
+      { method: "POST" },
+      RECEIPT_FETCH_TIMEOUT_MS,
+    )
+
+    const expectation = expect(pending).rejects.toMatchObject({
+      name: "AbortError",
+    })
+    await vi.advanceTimersByTimeAsync(RECEIPT_FETCH_TIMEOUT_MS)
+    await expectation
+  })
+})

--- a/demos/payments/src/stripe-settlement.test.ts
+++ b/demos/payments/src/stripe-settlement.test.ts
@@ -2,9 +2,12 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 import {
   RECEIPT_FETCH_TIMEOUT_MS,
+  STRIPE_SETTLEMENT_TTL_MS,
   createStripeSettlementTracker,
   fetchWithTimeout,
   isDemoStripeEventId,
+  signDemoStripeEvent,
+  verifyDemoStripeSignature,
 } from "./stripe-settlement"
 
 describe("isDemoStripeEventId", () => {
@@ -22,70 +25,123 @@ describe("isDemoStripeEventId", () => {
   })
 })
 
+describe("demo Stripe webhook HMAC", () => {
+  it("accepts a matching signature and rejects forgeries", () => {
+    const reference = "req_1:stripe-usd"
+    const eventId = "evt_abc"
+    const signature = signDemoStripeEvent(eventId, reference)
+
+    expect(verifyDemoStripeSignature(eventId, reference, signature)).toBe(true)
+    expect(
+      verifyDemoStripeSignature(eventId, reference, "deadbeef"),
+    ).toBe(false)
+    expect(
+      verifyDemoStripeSignature(eventId, "other-ref", signature),
+    ).toBe(false)
+  })
+})
+
 describe("createStripeSettlementTracker", () => {
   const expected = {
     paymentRequestId: "req_1",
     paymentOptionId: "stripe-usd",
   }
+  const reference = "req_1:stripe-usd"
+  const eventId = "evt_abc"
+  const signature = signDemoStripeEvent(eventId, reference)
 
   it("verifies only after a matching payment URL was issued", () => {
     const tracker = createStripeSettlementTracker()
-    const reference = "req_1:stripe-usd"
 
     expect(
-      tracker.consumeVerified(reference, "evt_abc", expected).ok,
+      tracker.verify(reference, eventId, signature, expected).ok,
     ).toBe(false)
 
     tracker.issue(reference, expected)
-    expect(
-      tracker.consumeVerified(reference, "evt_abc", expected),
-    ).toEqual({ ok: true })
+    expect(tracker.verify(reference, eventId, signature, expected)).toEqual({
+      ok: true,
+    })
 
-    // One-time: a second callback cannot reuse the same settlement.
+    // Idempotent: the same verified event can retry before commit.
+    expect(tracker.verify(reference, eventId, signature, expected)).toEqual({
+      ok: true,
+    })
+
+    tracker.commit(reference)
     expect(
-      tracker.consumeVerified(reference, "evt_abc", expected).ok,
+      tracker.verify(reference, eventId, signature, expected).ok,
     ).toBe(false)
   })
 
   it("rejects mismatched payment request or option", () => {
     const tracker = createStripeSettlementTracker()
-    const reference = "req_1:stripe-usd"
     tracker.issue(reference, expected)
 
     expect(
-      tracker.consumeVerified(reference, "evt_abc", {
+      tracker.verify(reference, eventId, signature, {
         paymentRequestId: "req_other",
         paymentOptionId: "stripe-usd",
       }).ok,
     ).toBe(false)
 
     expect(
-      tracker.consumeVerified(reference, "evt_abc", {
+      tracker.verify(reference, eventId, signature, {
         paymentRequestId: "req_1",
         paymentOptionId: "other",
       }).ok,
     ).toBe(false)
   })
 
-  it("rejects invalid event ids even when issued", () => {
+  it("rejects invalid event ids and unsigned events even when issued", () => {
     const tracker = createStripeSettlementTracker()
-    const reference = "req_1:stripe-usd"
     tracker.issue(reference, expected)
 
-    expect(tracker.consumeVerified(reference, "bad", expected).ok).toBe(false)
-    // Still pending after a bad event id — a valid callback can still succeed.
+    expect(tracker.verify(reference, "bad", signature, expected).ok).toBe(
+      false,
+    )
     expect(
-      tracker.consumeVerified(reference, "evt_ok", expected),
-    ).toEqual({ ok: true })
+      tracker.verify(reference, eventId, "forged-signature", expected).ok,
+    ).toBe(false)
+    // Still pending after a bad attempt — a valid callback can still succeed.
+    expect(tracker.verify(reference, eventId, signature, expected)).toEqual({
+      ok: true,
+    })
+  })
+
+  it("rejects a different event after one has already been verified", () => {
+    const tracker = createStripeSettlementTracker()
+    tracker.issue(reference, expected)
+    expect(tracker.verify(reference, eventId, signature, expected).ok).toBe(
+      true,
+    )
+
+    const otherEvent = "evt_other"
+    const otherSig = signDemoStripeEvent(otherEvent, reference)
+    expect(
+      tracker.verify(reference, otherEvent, otherSig, expected).ok,
+    ).toBe(false)
   })
 
   it("release drops a pending settlement without verifying", () => {
     const tracker = createStripeSettlementTracker()
-    const reference = "req_1:stripe-usd"
     tracker.issue(reference, expected)
     tracker.release(reference)
     expect(
-      tracker.consumeVerified(reference, "evt_abc", expected).ok,
+      tracker.verify(reference, eventId, signature, expected).ok,
+    ).toBe(false)
+  })
+
+  it("expires abandoned pending settlements after the TTL", () => {
+    let now = 1_000_000
+    const tracker = createStripeSettlementTracker({
+      ttlMs: STRIPE_SETTLEMENT_TTL_MS,
+      now: () => now,
+    })
+
+    tracker.issue(reference, expected)
+    now += STRIPE_SETTLEMENT_TTL_MS + 1
+    expect(
+      tracker.verify(reference, eventId, signature, expected).ok,
     ).toBe(false)
   })
 })
@@ -96,19 +152,20 @@ describe("fetchWithTimeout", () => {
     vi.useRealTimers()
   })
 
-  it("passes AbortSignal to fetch", async () => {
+  it("passes AbortSignal to fetch and buffers the body", async () => {
     const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
       expect(init?.signal).toBeInstanceOf(AbortSignal)
-      return new Response("{}", { status: 200 })
+      return new Response('{"ok":true}', { status: 200 })
     })
     vi.stubGlobal("fetch", fetchMock)
 
-    await fetchWithTimeout("https://example.test/receipt", {
+    const response = await fetchWithTimeout("https://example.test/receipt", {
       method: "POST",
       body: "{}",
     })
 
     expect(fetchMock).toHaveBeenCalledOnce()
+    expect(await response.json()).toEqual({ ok: true })
   })
 
   it("aborts when the request exceeds the timeout", async () => {
@@ -121,6 +178,43 @@ describe("fetchWithTimeout", () => {
             reject(new DOMException("The operation was aborted.", "AbortError"))
           })
         })
+      }),
+    )
+
+    const pending = fetchWithTimeout(
+      "https://example.test/receipt",
+      { method: "POST" },
+      RECEIPT_FETCH_TIMEOUT_MS,
+    )
+
+    const expectation = expect(pending).rejects.toMatchObject({
+      name: "AbortError",
+    })
+    await vi.advanceTimersByTimeAsync(RECEIPT_FETCH_TIMEOUT_MS)
+    await expectation
+  })
+
+  it("aborts when the response body stalls past the deadline", async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init?: RequestInit) => {
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            init?.signal?.addEventListener("abort", () => {
+              controller.error(
+                new DOMException("The operation was aborted.", "AbortError"),
+              )
+            })
+            // Never enqueue — body hangs until abort.
+          },
+        })
+        return Promise.resolve(
+          new Response(body, {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        )
       }),
     )
 

--- a/demos/payments/src/stripe-settlement.ts
+++ b/demos/payments/src/stripe-settlement.ts
@@ -1,0 +1,88 @@
+/**
+ * Demo-only Stripe settlement tracking for the Payment Service callback.
+ *
+ * Production services should verify a signed Stripe webhook (or Events API
+ * object) that matches the payment request and option before treating the
+ * charge as settled. This tracker approximates that gate for the local demo:
+ * a callback may only proceed after the matching payment URL was issued.
+ */
+
+export type PendingStripeSettlement = {
+  paymentRequestId: string
+  paymentOptionId: string
+}
+
+export type StripeSettlementTracker = {
+  issue: (reference: string, settlement: PendingStripeSettlement) => void
+  /**
+   * One-time consume: validates the demo event id and that this payment
+   * attempt was previously issued a payment URL.
+   */
+  consumeVerified: (
+    reference: string,
+    eventId: string,
+    expected: PendingStripeSettlement,
+  ) => { ok: true } | { ok: false; reason: string }
+  release: (reference: string) => void
+}
+
+/** Stripe event ids look like `evt_...` in the Events API. */
+export function isDemoStripeEventId(eventId: string): boolean {
+  return /^evt_[A-Za-z0-9]+$/.test(eventId)
+}
+
+export function createStripeSettlementTracker(): StripeSettlementTracker {
+  const pending = new Map<string, PendingStripeSettlement>()
+
+  return {
+    issue(reference, settlement) {
+      pending.set(reference, settlement)
+    },
+    consumeVerified(reference, eventId, expected) {
+      if (!isDemoStripeEventId(eventId)) {
+        return { ok: false, reason: "Invalid Stripe event id" }
+      }
+
+      const issued = pending.get(reference)
+      if (
+        !issued ||
+        issued.paymentRequestId !== expected.paymentRequestId ||
+        issued.paymentOptionId !== expected.paymentOptionId
+      ) {
+        return {
+          ok: false,
+          reason: "No verified Stripe settlement for this payment attempt",
+        }
+      }
+
+      pending.delete(reference)
+      return { ok: true }
+    },
+    release(reference) {
+      pending.delete(reference)
+    },
+  }
+}
+
+export const RECEIPT_FETCH_TIMEOUT_MS = 10_000
+
+/**
+ * `fetch` with an AbortController timeout so a hung Receipt Service cannot
+ * hold a spend reservation until the rolling window expires.
+ */
+export async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs = RECEIPT_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: controller.signal,
+    })
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/demos/payments/src/stripe-settlement.ts
+++ b/demos/payments/src/stripe-settlement.ts
@@ -4,25 +4,46 @@
  * Production services should verify a signed Stripe webhook (or Events API
  * object) that matches the payment request and option before treating the
  * charge as settled. This tracker approximates that gate for the local demo:
- * a callback may only proceed after the matching payment URL was issued.
+ * a callback may only proceed after the matching payment URL was issued and
+ * the request carries an HMAC matching the demo webhook secret.
  */
+
+import { createHmac, timingSafeEqual } from "node:crypto"
+
+/** Abandoned checkout TTL — mirrors a short-lived Stripe payment link. */
+export const STRIPE_SETTLEMENT_TTL_MS = 30 * 60 * 1000
+
+/**
+ * Demo stand-in for Stripe's webhook signing secret (`whsec_...`).
+ * Real services verify the `Stripe-Signature` header instead.
+ */
+export const DEMO_STRIPE_WEBHOOK_SECRET = "whsec_demo_ack_payments"
 
 export type PendingStripeSettlement = {
   paymentRequestId: string
   paymentOptionId: string
 }
 
+type SettlementEntry = PendingStripeSettlement & {
+  issuedAt: number
+  /** Set once a signed Stripe-shaped event has been accepted. */
+  verifiedEventId?: string
+}
+
 export type StripeSettlementTracker = {
   issue: (reference: string, settlement: PendingStripeSettlement) => void
   /**
-   * One-time consume: validates the demo event id and that this payment
-   * attempt was previously issued a payment URL.
+   * Verify settlement without consuming it. Keeps state until `commit` so a
+   * receipt-service failure can retry with the same Stripe event.
    */
-  consumeVerified: (
+  verify: (
     reference: string,
     eventId: string,
+    signature: string,
     expected: PendingStripeSettlement,
   ) => { ok: true } | { ok: false; reason: string }
+  /** One-time commit after receipt issuance succeeds. */
+  commit: (reference: string) => void
   release: (reference: string) => void
 }
 
@@ -31,16 +52,86 @@ export function isDemoStripeEventId(eventId: string): boolean {
   return /^evt_[A-Za-z0-9]+$/.test(eventId)
 }
 
-export function createStripeSettlementTracker(): StripeSettlementTracker {
-  const pending = new Map<string, PendingStripeSettlement>()
+/**
+ * Demo HMAC over `eventId.reference`, analogous to Stripe webhook signing.
+ */
+export function signDemoStripeEvent(
+  eventId: string,
+  reference: string,
+  secret = DEMO_STRIPE_WEBHOOK_SECRET,
+): string {
+  return createHmac("sha256", secret)
+    .update(`${eventId}.${reference}`)
+    .digest("hex")
+}
+
+export function verifyDemoStripeSignature(
+  eventId: string,
+  reference: string,
+  signature: string,
+  secret = DEMO_STRIPE_WEBHOOK_SECRET,
+): boolean {
+  if (!signature) {
+    return false
+  }
+  const expected = signDemoStripeEvent(eventId, reference, secret)
+  try {
+    const a = Buffer.from(expected, "utf8")
+    const b = Buffer.from(signature, "utf8")
+    return a.length === b.length && timingSafeEqual(a, b)
+  } catch {
+    return false
+  }
+}
+
+export function createStripeSettlementTracker(
+  options: {
+    ttlMs?: number
+    now?: () => number
+    webhookSecret?: string
+  } = {},
+): StripeSettlementTracker {
+  const pending = new Map<string, SettlementEntry>()
+  const ttlMs = options.ttlMs ?? STRIPE_SETTLEMENT_TTL_MS
+  const now = options.now ?? Date.now
+  const webhookSecret = options.webhookSecret ?? DEMO_STRIPE_WEBHOOK_SECRET
+
+  function pruneExpired() {
+    const cutoff = now() - ttlMs
+    for (const [reference, entry] of pending) {
+      if (entry.issuedAt < cutoff) {
+        pending.delete(reference)
+      }
+    }
+  }
 
   return {
     issue(reference, settlement) {
-      pending.set(reference, settlement)
+      pruneExpired()
+      pending.set(reference, {
+        ...settlement,
+        issuedAt: now(),
+      })
     },
-    consumeVerified(reference, eventId, expected) {
+    verify(reference, eventId, signature, expected) {
+      pruneExpired()
+
       if (!isDemoStripeEventId(eventId)) {
         return { ok: false, reason: "Invalid Stripe event id" }
+      }
+
+      if (
+        !verifyDemoStripeSignature(
+          eventId,
+          reference,
+          signature,
+          webhookSecret,
+        )
+      ) {
+        return {
+          ok: false,
+          reason: "Stripe event signature verification failed",
+        }
       }
 
       const issued = pending.get(reference)
@@ -55,8 +146,19 @@ export function createStripeSettlementTracker(): StripeSettlementTracker {
         }
       }
 
-      pending.delete(reference)
+      // Idempotent retry: same verified event may re-enter after a receipt failure.
+      if (issued.verifiedEventId && issued.verifiedEventId !== eventId) {
+        return {
+          ok: false,
+          reason: "Settlement already verified with a different Stripe event",
+        }
+      }
+
+      issued.verifiedEventId = eventId
       return { ok: true }
+    },
+    commit(reference) {
+      pending.delete(reference)
     },
     release(reference) {
       pending.delete(reference)
@@ -67,8 +169,9 @@ export function createStripeSettlementTracker(): StripeSettlementTracker {
 export const RECEIPT_FETCH_TIMEOUT_MS = 10_000
 
 /**
- * `fetch` with an AbortController timeout so a hung Receipt Service cannot
- * hold a spend reservation until the rolling window expires.
+ * `fetch` with an AbortController timeout that stays armed through response
+ * body consumption, so a stalled Receipt Service body cannot hold a spend
+ * reservation until the rolling window expires.
  */
 export async function fetchWithTimeout(
   url: string,
@@ -78,9 +181,16 @@ export async function fetchWithTimeout(
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), timeoutMs)
   try {
-    return await fetch(url, {
+    const response = await fetch(url, {
       ...init,
       signal: controller.signal,
+    })
+    // Buffer the body under the same deadline before clearing the timer.
+    const body = await response.arrayBuffer()
+    return new Response(body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
     })
   } finally {
     clearTimeout(timeout)


### PR DESCRIPTION
## Summary
- Add an in-memory rolling-window spend ledger under `demos/payments` so the policy guard bounds cumulative spend, not only a per-transaction cap.
- Introduce `authorizePayment` on top of unchanged `evaluatePaymentPolicy`, with check-and-reserve as one synchronous step.
- Key reservations by payment request id + payment option id so the Stripe URL + callback path authorizes once; commit on receipt, release on failure.

Fixes #138.

## Notes
Everything stays in `demos/payments` (no package/protocol change). Budget breaches return `denied`, matching the existing per-transaction cap. Still demo-grade: in-memory, single-instance, denies rather than escalating to human approval.

## Test plan
- [ ] `pnpm --filter ./demos/payments exec vitest run`
- [ ] Confirm split-attack test denies the 4th payment at the window limit
- [ ] Confirm idempotent re-authorization does not double-count
- [ ] Confirm commit/release and window expiry behaviour

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rolling-window cumulative spend limits alongside per-transaction caps.
  * Payment authorization now tracks spending by payer and currency, preventing transactions that exceed configured budgets.
  * Added retry-safe reservation handling for successful, failed, and repeated payment attempts.
  * Settled payments can continue through receipt issuance when they exceed the rolling budget.
  * Payment requests and receipts are signed using the payer identity.
  * Added verified payment settlement handling, expiration of abandoned settlements, and timeout protection for receipt retrieval.
* **Documentation**
  * Updated payment policy documentation with budget rules, approval requirements, and demo ledger limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->