### PR TITLE
fix(keys): accept uppercase 0X prefix in isHexString

### DIFF
--- a/.changeset/is-hex-string-uppercase-prefix.md
+++ b/.changeset/is-hex-string-uppercase-prefix.md
@@ -1,0 +1,5 @@
+---
+"@agentcommercekit/keys": patch
+---
+
+Accept an uppercase `0X` prefix in `isHexString`, matching `hexStringToBytes`.

--- a/packages/keys/src/encoding/hex.test.ts
+++ b/packages/keys/src/encoding/hex.test.ts
@@ -40,6 +40,11 @@ describe("isHexString", () => {
     expect(isHexString("0x1234567890abcdef")).toBe(true)
   })
 
+  test("returns true for valid hex strings with uppercase 0X prefix", () => {
+    // `hexStringToBytes` already accepts this form; the guard must agree.
+    expect(isHexString("0XABCDEF")).toBe(true)
+  })
+
   test("returns true for valid hex strings without 0x prefix", () => {
     expect(isHexString("1234567890abcdef")).toBe(true)
   })

--- a/packages/keys/src/encoding/hex.ts
+++ b/packages/keys/src/encoding/hex.ts
@@ -47,6 +47,9 @@ export function isHexString(value: unknown): value is string {
     return false
   }
 
-  const hexWithoutPrefix = value.startsWith("0x") ? value.slice(2) : value
+  // Match `hexStringToBytes`: accept both `0x` and `0X` prefixes.
+  const hexWithoutPrefix = value.toLowerCase().startsWith("0x")
+    ? value.slice(2)
+    : value
   return /^[0-9A-Fa-f]+$/.test(hexWithoutPrefix)
 }


### PR DESCRIPTION
## Summary
- `isHexString` only stripped a lowercase `0x` prefix, while `hexStringToBytes` already accepts `0X…`.
- Make the guard strip the prefix case-insensitively so values the decoder accepts also pass the type guard.
- Add a regression test for `0XABCDEF`.

This is distinct from #161 (bare `0x` / empty body); that PR does not make the prefix check case-insensitive.

## Test plan
- [ ] `pnpm --filter @agentcommercekit/keys exec vitest run src/encoding/hex.test.ts`
- [ ] Confirm `isHexString('0XABCDEF') === true`
- [ ] Confirm invalid hex still returns false

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hex string validation now accepts both lowercase `0x` and uppercase `0X` prefixes, matching hex string conversion behavior.

* **Tests**
  * Added coverage for valid hexadecimal strings using the uppercase `0X` prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->