### PR TITLE
fix(jwt): include curve in "Unsupported algorithm" error message

### DIFF
--- a/.changeset/fix-signer-unsupported-algorithm-error.md
+++ b/.changeset/fix-signer-unsupported-algorithm-error.md
@@ -1,0 +1,12 @@
+---
+"@agentcommercekit/jwt": patch
+---
+
+`createJwtSigner` now reports which curve it could not handle.
+
+The `default` branch called `new Error("Unsupported algorithm", keypair.curve)`.
+`Error`'s second argument is an `ErrorOptions` object (`{ cause }`), not a
+message part, so passing a string there is silently dropped at runtime and
+fails to type-check under `strict` TypeScript. The curve is now interpolated
+into the message instead, so the thrown error actually names the unsupported
+curve.

--- a/packages/jwt/src/signer.test.ts
+++ b/packages/jwt/src/signer.test.ts
@@ -1,6 +1,5 @@
 import { generateKeypair } from "@agentcommercekit/keys"
 import { describe, expect, test } from "vitest"
-
 import { createJwtSigner } from "./signer"
 
 describe("createJwtSigner", () => {
@@ -66,6 +65,24 @@ describe("createJwtSigner", () => {
     const signature2 = await signer2(data)
 
     expect(signature1).not.toBe(signature2)
+  })
+
+  test("throws a descriptive error for an unsupported curve", async () => {
+    const keypair = await generateKeypair("secp256k1")
+    // Simulate a Keypair with an invalid/unsupported curve, e.g. one that
+    // arrived from untrusted or future data and was never runtime-validated.
+    const invalidKeypair = {
+      ...keypair,
+      curve: "invalid-curve",
+    }
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- intentionally passing invalid input to exercise runtime validation
+    const signerInput = invalidKeypair as unknown as Parameters
+      typeof createJwtSigner
+    >[0]
+
+    expect(() => createJwtSigner(signerInput)).toThrow(
+      "Unsupported algorithm: invalid-curve",
+    )
   })
 
   test("handles both string and Uint8Array input", async () => {

--- a/packages/jwt/src/signer.test.ts
+++ b/packages/jwt/src/signer.test.ts
@@ -76,7 +76,7 @@ describe("createJwtSigner", () => {
       curve: "invalid-curve",
     }
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- intentionally passing invalid input to exercise runtime validation
-    const signerInput = invalidKeypair as unknown as Parameters
+    const signerInput = invalidKeypair as unknown as Parameters<
       typeof createJwtSigner
     >[0]
 

--- a/packages/jwt/src/signer.ts
+++ b/packages/jwt/src/signer.ts
@@ -22,6 +22,6 @@ export function createJwtSigner(keypair: Keypair): JwtSigner {
     case "Ed25519":
       return EdDSASigner(keypair.privateKey)
     default:
-      throw new Error("Unsupported algorithm", keypair.curve)
+      throw new Error(`Unsupported algorithm: ${String(keypair.curve)}`)
   }
 }


### PR DESCRIPTION
## Problem

`createJwtSigner`'s `default` branch (for an unsupported `Keypair.curve`)
calls:

    throw new Error("Unsupported algorithm", keypair.curve)

`Error`'s second constructor argument is an `ErrorOptions` object (`{ cause }`),
not a message segment. Passing a string there:

- is silently ignored at runtime — the thrown error never names the curve
  that wasn't supported, which makes the failure hard to debug
- fails to type-check under `strict` TypeScript (verified independently:
  `TS2345: Argument of type 'KeyCurve' is not assignable to parameter of
  type 'ErrorOptions | undefined'`)

This path is reachable in practice since `Keypair.curve` isn't
runtime-validated before reaching `createJwtSigner` (e.g. a keypair
constructed from untrusted or future data).

## Fix

Interpolate the curve into the error message:

    throw new Error(`Unsupported algorithm: ${String(keypair.curve)}`)

## Test

Added a regression test (`signer.test.ts`) that constructs a `Keypair` with
an invalid curve and asserts `createJwtSigner` throws
`"Unsupported algorithm: invalid-curve"`.

Verification:
- `corepack pnpm --filter @agentcommercekit/jwt test -- --run` — 26/26 passing
  (5 test files)
- `corepack pnpm run lint` — 0 warnings, 0 errors
- `corepack pnpm exec oxfmt --check ...` — all changed files correctly formatted
- `git diff --check` — no whitespace errors

Also adds a `.changeset` entry (patch bump for `@agentcommercekit/jwt`), per
this repo's convention for bug fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages when an unsupported signing curve is used, clearly identifying the invalid curve.
  - Resolved type-checking issues related to unsupported algorithm errors, improving reliability during development and builds.

- **Tests**
  - Added coverage confirming that invalid curves produce descriptive error messages, helping ensure consistent diagnostics for unsupported signing configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->