### PR TITLE
fix(ack-pay): reject negative payment option decimals

### DIFF
--- a/.changeset/ack-pay-decimals-min-value.md
+++ b/.changeset/ack-pay-decimals-min-value.md
@@ -1,0 +1,7 @@
+---
+"@agentcommercekit/ack-pay": patch
+---
+
+Reject negative `decimals` in the Valibot payment option schema instead of clamping them to `0`.
+
+`paymentOptionSchema` used `v.toMinValue(0)`, which silently rewrites negative values. That diverged from the Zod schema (`z.number().int().nonnegative()`) and could hide invalid payment precision. Switch to `v.minValue(0)` so both schemas reject the same inputs.

--- a/packages/ack-pay/src/schemas/payment-option.test.ts
+++ b/packages/ack-pay/src/schemas/payment-option.test.ts
@@ -35,3 +35,25 @@ describe("paymentOptionSchema amount", () => {
     },
   )
 })
+
+function acceptsDecimals(decimals: number) {
+  const value = { ...paymentOption, amount: 10, decimals }
+
+  return {
+    valibot: v.safeParse(valibotPaymentOptionSchema, value).success,
+    zod: zodPaymentOptionSchema.safeParse(value).success,
+  }
+}
+
+describe("paymentOptionSchema decimals", () => {
+  it.each([0, 2, 18])("accepts non-negative decimals %s", (decimals) => {
+    expect(acceptsDecimals(decimals)).toEqual({ valibot: true, zod: true })
+  })
+
+  it.each([-1, -6, 1.5])(
+    "rejects invalid decimals %s instead of clamping",
+    (decimals) => {
+      expect(acceptsDecimals(decimals)).toEqual({ valibot: false, zod: false })
+    },
+  )
+})

--- a/packages/ack-pay/src/schemas/valibot.ts
+++ b/packages/ack-pay/src/schemas/valibot.ts
@@ -17,7 +17,7 @@ export const paymentOptionSchema = v.object({
     v.pipe(v.number(), v.integer(), v.gtValue(0)),
     positiveIntegerString,
   ]),
-  decimals: v.pipe(v.number(), v.integer(), v.toMinValue(0)),
+  decimals: v.pipe(v.number(), v.integer(), v.minValue(0)),
   currency: v.string(),
   recipient: v.string(),
   network: v.optional(v.string()),


### PR DESCRIPTION
## Summary
- Valibot `paymentOptionSchema.decimals` used `v.toMinValue(0)`, which **clamps** negative values to `0` instead of rejecting them.
- Zod already uses `.nonnegative()`, so the two schema implementations disagreed.
- Switch Valibot to `v.minValue(0)` and add parity tests covering accept/reject cases.

Fixes #147

## Test plan
- [x] `pnpm --filter @agentcommercekit/ack-pay exec vitest run src/schemas/payment-option.test.ts`
- [x] Confirm `decimals: -1` fails in both Valibot and Zod
- [x] Confirm `decimals: 0 | 2 | 18` still succeeds

## AI usage disclosure
AI-assisted with Cursor for repo navigation, the schema change, tests, and changeset. I reviewed and understand the Valibot `toMinValue` vs `minValue` distinction and that this aligns Valibot with the existing Zod validator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Negative decimal values in payment options are now rejected instead of being silently changed to zero.
  - Decimal values must be non-negative whole numbers, with valid values such as 0, 2, and 18 accepted.

- **Tests**
  - Added coverage for valid and invalid decimal values across supported validation formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->