### PR TITLE
fix(ack-pay): reject empty payment request and option fields

### DIFF
--- a/.changeset/ack-pay-reject-empty-payment-fields.md
+++ b/.changeset/ack-pay-reject-empty-payment-fields.md
@@ -1,0 +1,7 @@
+---
+"@agentcommercekit/ack-pay": patch
+---
+
+Reject empty payment request and payment option identifiers.
+
+`paymentOptionSchema` accepted empty strings for `id`, `currency`, and `recipient`, and `paymentRequestSchema` / `paymentReceiptClaimSchema` accepted empty request and option ids. Require non-empty strings for these fields in both the Valibot and Zod schemas so HTTP 402 bodies and verified payment request tokens cannot carry blank identifiers.

--- a/packages/ack-pay/src/schemas/schemas.test.ts
+++ b/packages/ack-pay/src/schemas/schemas.test.ts
@@ -1,8 +1,14 @@
 import * as v from "valibot"
 import { describe, expect, it } from "vitest"
 
-import { paymentRequestSchema as valibotPaymentRequestSchema } from "./valibot"
-import { paymentRequestSchema as zodPaymentRequestSchema } from "./zod"
+import {
+  paymentOptionSchema as valibotPaymentOptionSchema,
+  paymentRequestSchema as valibotPaymentRequestSchema,
+} from "./valibot"
+import {
+  paymentOptionSchema as zodPaymentOptionSchema,
+  paymentRequestSchema as zodPaymentRequestSchema,
+} from "./zod"
 
 const paymentRequest = {
   id: "test-payment-request-id",
@@ -16,6 +22,8 @@ const paymentRequest = {
     },
   ],
 }
+
+const paymentOption = paymentRequest.paymentOptions[0]
 
 describe("paymentRequestSchema", () => {
   it("rejects invalid expiresAt strings instead of throwing", () => {
@@ -42,5 +50,47 @@ describe("paymentRequestSchema", () => {
       const zod = zodPaymentRequestSchema.safeParse(input)
       expect(zod.success && zod.data.expiresAt).toBe(expected)
     }
+  })
+})
+
+describe.each([
+  [
+    "valibot",
+    {
+      paymentRequest: (input: unknown) =>
+        v.safeParse(valibotPaymentRequestSchema, input).success,
+      paymentOption: (input: unknown) =>
+        v.safeParse(valibotPaymentOptionSchema, input).success,
+    },
+  ],
+  [
+    "zod",
+    {
+      paymentRequest: (input: unknown) =>
+        zodPaymentRequestSchema.safeParse(input).success,
+      paymentOption: (input: unknown) =>
+        zodPaymentOptionSchema.safeParse(input).success,
+    },
+  ],
+] as const)("%s rejects empty required payment fields", (_name, schema) => {
+  it.each(["id", "currency", "recipient"] as const)(
+    "rejects a payment option with an empty %s",
+    (field) => {
+      expect(
+        schema.paymentOption({
+          ...paymentOption,
+          [field]: "",
+        }),
+      ).toBe(false)
+    },
+  )
+
+  it("rejects a payment request with an empty id", () => {
+    expect(
+      schema.paymentRequest({
+        ...paymentRequest,
+        id: "",
+      }),
+    ).toBe(false)
   })
 })

--- a/packages/ack-pay/src/schemas/schemas.test.ts
+++ b/packages/ack-pay/src/schemas/schemas.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, it } from "vitest"
 
 import {
   paymentOptionSchema as valibotPaymentOptionSchema,
+  paymentReceiptClaimSchema as valibotPaymentReceiptClaimSchema,
   paymentRequestSchema as valibotPaymentRequestSchema,
 } from "./valibot"
 import {
   paymentOptionSchema as zodPaymentOptionSchema,
+  paymentReceiptClaimSchema as zodPaymentReceiptClaimSchema,
   paymentRequestSchema as zodPaymentRequestSchema,
 } from "./zod"
 
@@ -24,6 +26,14 @@ const paymentRequest = {
 }
 
 const paymentOption = paymentRequest.paymentOptions[0]
+
+const paymentRequestToken =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+
+const paymentReceiptClaim = {
+  paymentRequestToken,
+  paymentOptionId: "test-payment-option-id",
+}
 
 describe("paymentRequestSchema", () => {
   it("rejects invalid expiresAt strings instead of throwing", () => {
@@ -61,6 +71,8 @@ describe.each([
         v.safeParse(valibotPaymentRequestSchema, input).success,
       paymentOption: (input: unknown) =>
         v.safeParse(valibotPaymentOptionSchema, input).success,
+      paymentReceiptClaim: (input: unknown) =>
+        v.safeParse(valibotPaymentReceiptClaimSchema, input).success,
     },
   ],
   [
@@ -70,6 +82,8 @@ describe.each([
         zodPaymentRequestSchema.safeParse(input).success,
       paymentOption: (input: unknown) =>
         zodPaymentOptionSchema.safeParse(input).success,
+      paymentReceiptClaim: (input: unknown) =>
+        zodPaymentReceiptClaimSchema.safeParse(input).success,
     },
   ],
 ] as const)("%s rejects empty required payment fields", (_name, schema) => {
@@ -90,6 +104,15 @@ describe.each([
       schema.paymentRequest({
         ...paymentRequest,
         id: "",
+      }),
+    ).toBe(false)
+  })
+
+  it("rejects a payment receipt claim with an empty paymentOptionId", () => {
+    expect(
+      schema.paymentReceiptClaim({
+        ...paymentReceiptClaim,
+        paymentOptionId: "",
       }),
     ).toBe(false)
   })

--- a/packages/ack-pay/src/schemas/valibot.ts
+++ b/packages/ack-pay/src/schemas/valibot.ts
@@ -3,6 +3,7 @@ import { jwtStringSchema } from "@agentcommercekit/jwt/schemas/valibot"
 import * as v from "valibot"
 
 const urlOrDidUri = v.union([v.pipe(v.string(), v.url()), didUriSchema])
+const nonEmptyString = v.pipe(v.string(), v.minLength(1))
 const positiveIntegerString = v.pipe(v.string(), v.regex(/^[1-9]\d*$/))
 
 const timestampSchema = v.pipe(
@@ -12,21 +13,21 @@ const timestampSchema = v.pipe(
 )
 
 export const paymentOptionSchema = v.object({
-  id: v.string(),
+  id: nonEmptyString,
   amount: v.union([
     v.pipe(v.number(), v.integer(), v.gtValue(0)),
     positiveIntegerString,
   ]),
   decimals: v.pipe(v.number(), v.integer(), v.toMinValue(0)),
-  currency: v.string(),
-  recipient: v.string(),
+  currency: nonEmptyString,
+  recipient: nonEmptyString,
   network: v.optional(v.string()),
   paymentService: v.optional(urlOrDidUri),
   receiptService: v.optional(urlOrDidUri),
 })
 
 export const paymentRequestSchema = v.object({
-  id: v.string(),
+  id: nonEmptyString,
   description: v.optional(v.string()),
   serviceCallback: v.optional(v.pipe(v.string(), v.url())),
   expiresAt: v.optional(timestampSchema),
@@ -38,6 +39,6 @@ export const paymentRequestSchema = v.object({
 
 export const paymentReceiptClaimSchema = v.object({
   paymentRequestToken: jwtStringSchema,
-  paymentOptionId: v.string(),
+  paymentOptionId: nonEmptyString,
   metadata: v.optional(v.record(v.string(), v.unknown())),
 })

--- a/packages/ack-pay/src/schemas/zod.ts
+++ b/packages/ack-pay/src/schemas/zod.ts
@@ -3,6 +3,7 @@ import { jwtStringSchema } from "@agentcommercekit/jwt/schemas/zod"
 import * as z from "zod"
 
 const urlOrDidUri = z.union([z.url(), didUriSchema])
+const nonEmptyString = z.string().min(1)
 const positiveIntegerString = z.string().regex(/^[1-9]\d*$/)
 
 const timestampSchema = z
@@ -22,18 +23,18 @@ const timestampSchema = z
   })
 
 export const paymentOptionSchema = z.object({
-  id: z.string(),
+  id: nonEmptyString,
   amount: z.union([z.number().int().positive(), positiveIntegerString]),
   decimals: z.number().int().nonnegative(),
-  currency: z.string(),
-  recipient: z.string(),
+  currency: nonEmptyString,
+  recipient: nonEmptyString,
   network: z.string().optional(),
   paymentService: urlOrDidUri.optional(),
   receiptService: urlOrDidUri.optional(),
 })
 
 export const paymentRequestSchema = z.object({
-  id: z.string(),
+  id: nonEmptyString,
   description: z.string().optional(),
   serviceCallback: z.url().optional(),
   expiresAt: timestampSchema.optional(),
@@ -42,6 +43,6 @@ export const paymentRequestSchema = z.object({
 
 export const paymentReceiptClaimSchema = z.object({
   paymentRequestToken: jwtStringSchema,
-  paymentOptionId: z.string(),
+  paymentOptionId: nonEmptyString,
   metadata: z.record(z.string(), z.unknown()).optional(),
 })


### PR DESCRIPTION
## Summary
- Payment option `id` / `currency` / `recipient`, payment request `id`, and receipt claim `paymentOptionId` previously accepted empty strings via bare `v.string()` / `z.string()`.
- Other fields already reject invalid values (e.g. `amount`), so blank identifiers were an inconsistency rather than an intentional allowance.
- Introduce a shared non-empty string helper in both Valibot and Zod schemas, with parity tests.

This is a clean rebase of the same fix attempted in #183 (currently conflicting with `main`).

## Test plan
- [x] `pnpm --filter @agentcommercekit/ack-pay exec vitest run src/schemas/schemas.test.ts`
- [x] Empty `id` / `currency` / `recipient` on a payment option are rejected by both schemas
- [x] Empty payment request `id` is rejected by both schemas

## AI usage disclosure
AI-assisted with Cursor for identifying the empty-string acceptance, implementing the shared non-empty string validators, tests, and changeset. I reviewed the dual-schema change and understand why these fields need length checks at the schema gate used by HTTP 402 bodies and token verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Payment requests and options now reject empty identifiers, currencies, and recipient values.
  * Payment receipt claims now reject empty payment option identifiers.
  * Validation behavior is consistent across supported schema formats, helping prevent incomplete payment data from being accepted.

* **Tests**
  * Added coverage confirming empty required fields are rejected across payment requests, options, and receipt claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->