### PR TITLE
fix(ack-id): return reply nonce for response handshakes

### DIFF
--- a/.changeset/a2a-response-reply-nonce.md
+++ b/.changeset/a2a-response-reply-nonce.md
@@ -1,0 +1,5 @@
+---
+"@agentcommercekit/ack-id": patch
+---
+
+Return the fresh reply nonce from A2A response handshakes.

--- a/packages/ack-id/src/a2a/sign-message.test.ts
+++ b/packages/ack-id/src/a2a/sign-message.test.ts
@@ -9,6 +9,7 @@ import {
   createA2AHandshakePayload,
   createSignedA2AMessage,
 } from "./sign-message"
+import { generateRandomNonce } from "./random"
 import {
   agentDid,
   makeTextMessage,
@@ -136,6 +137,22 @@ describe("createA2AHandshakeMessage", () => {
     expect(result.jti).toBe("test-jti-1234")
     expect(result.nonce).toBe("test-nonce-1234")
     expect(result.message.role).toBe("agent")
+  })
+
+  it("returns the fresh reply nonce when responding to a handshake", async () => {
+    vi.mocked(generateRandomNonce).mockReturnValueOnce("fresh-reply-nonce")
+
+    const result = await createA2AHandshakeMessage(
+      "agent",
+      {
+        recipient: userDid,
+        vc: testCredential,
+        requestNonce: "initiator-nonce",
+      },
+      { did: agentDid, jwtSigner },
+    )
+
+    expect(result.nonce).toBe("fresh-reply-nonce")
   })
 
   it("returns the signed JWT in the message data part", async () => {

--- a/packages/ack-id/src/a2a/sign-message.test.ts
+++ b/packages/ack-id/src/a2a/sign-message.test.ts
@@ -3,13 +3,13 @@ import { createJwtSigner } from "@agentcommercekit/jwt"
 import { generateKeypair } from "@agentcommercekit/keys"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { generateRandomNonce } from "./random"
 import {
   createA2AHandshakeMessage,
   createA2AHandshakeMessageFromJwt,
   createA2AHandshakePayload,
   createSignedA2AMessage,
 } from "./sign-message"
-import { generateRandomNonce } from "./random"
 import {
   agentDid,
   makeTextMessage,

--- a/packages/ack-id/src/a2a/sign-message.ts
+++ b/packages/ack-id/src/a2a/sign-message.ts
@@ -122,7 +122,7 @@ export async function createA2AHandshakeMessage(
   return {
     sig: jwt,
     jti,
-    nonce: payload.nonce,
+    nonce: payload.replyNonce ?? payload.nonce,
     message,
   }
 }


### PR DESCRIPTION
## Summary

- Return `payload.replyNonce` from response handshakes while preserving initiator behavior.
- Add a regression test using a distinct generated reply nonce.
- Add an `ack-id` patch changeset.

## Verification

- `pnpm run build`
- `pnpm --filter @agentcommercekit/ack-id exec vitest run src/a2a/sign-message.test.ts`
- `pnpm --filter @agentcommercekit/ack-id test -- --run`
- `pnpm run lint`
- `pnpm run check:format`
- `pnpm run check:packages`

Fixes #174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - A2A response handshakes now return the fresh reply nonce, ensuring callers receive the correct nonce when responding to a prior handshake.

- **Documentation**
  - Added a patch release note for the acknowledgment ID package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->