### PR TITLE
fix(ack-pay): accept DID URIs for serviceCallback

### DIFF
--- a/.changeset/ack-pay-service-callback-did-uri.md
+++ b/.changeset/ack-pay-service-callback-did-uri.md
@@ -1,0 +1,5 @@
+---
+"@agentcommercekit/ack-pay": patch
+---
+
+Allow `paymentRequest.serviceCallback` to accept DID URIs in addition to URLs, matching the documented field contract and the existing `paymentService` / `receiptService` schemas.

--- a/packages/ack-pay/src/schemas/schemas.test.ts
+++ b/packages/ack-pay/src/schemas/schemas.test.ts
@@ -43,4 +43,23 @@ describe("paymentRequestSchema", () => {
       expect(zod.success && zod.data.expiresAt).toBe(expected)
     }
   })
+
+  it("accepts URL and DID URI serviceCallback values", () => {
+    for (const serviceCallback of [
+      "https://service.example.com/webhook/payment-complete",
+      "did:web:merchant.example",
+    ]) {
+      const input = { ...paymentRequest, serviceCallback }
+
+      expect(v.safeParse(valibotPaymentRequestSchema, input).success).toBe(true)
+      expect(zodPaymentRequestSchema.safeParse(input).success).toBe(true)
+    }
+  })
+
+  it("rejects invalid serviceCallback values", () => {
+    const input = { ...paymentRequest, serviceCallback: "not-a-url-or-did" }
+
+    expect(v.safeParse(valibotPaymentRequestSchema, input).success).toBe(false)
+    expect(zodPaymentRequestSchema.safeParse(input).success).toBe(false)
+  })
 })

--- a/packages/ack-pay/src/schemas/valibot.ts
+++ b/packages/ack-pay/src/schemas/valibot.ts
@@ -28,7 +28,7 @@ export const paymentOptionSchema = v.object({
 export const paymentRequestSchema = v.object({
   id: v.string(),
   description: v.optional(v.string()),
-  serviceCallback: v.optional(v.pipe(v.string(), v.url())),
+  serviceCallback: v.optional(urlOrDidUri),
   expiresAt: v.optional(timestampSchema),
   paymentOptions: v.pipe(
     v.tupleWithRest([paymentOptionSchema], paymentOptionSchema),

--- a/packages/ack-pay/src/schemas/zod.ts
+++ b/packages/ack-pay/src/schemas/zod.ts
@@ -35,7 +35,7 @@ export const paymentOptionSchema = z.object({
 export const paymentRequestSchema = z.object({
   id: z.string(),
   description: z.string().optional(),
-  serviceCallback: z.url().optional(),
+  serviceCallback: urlOrDidUri.optional(),
   expiresAt: timestampSchema.optional(),
   paymentOptions: z.array(paymentOptionSchema).nonempty(),
 })


### PR DESCRIPTION
## Summary
- Reuse `urlOrDidUri` for `paymentRequest.serviceCallback` in Valibot and Zod.
- Matches the documented URL-or-DID contract and sibling `paymentService` / `receiptService` fields.
- Add schema parity tests for DID acceptance and invalid rejection.

## Testing
- `pnpm --filter @agentcommercekit/ack-pay exec vitest run src/schemas/schemas.test.ts`

## AI usage disclosure
Assisted by Cursor. I verified the docs/schema mismatch, implemented the dual-schema change, and ran the focused tests myself.

Fixes #205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payment request service callbacks now accept DID URIs in addition to HTTPS URLs.
  * Invalid callback values continue to be rejected during validation.

* **Tests**
  * Added coverage for valid URLs, valid DID URIs, and invalid callback values across supported validation implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->