### PR TITLE
docs(did): fix createDidPkhUri JSDoc argument order

### DIFF
--- a/packages/did/src/methods/did-pkh.ts
+++ b/packages/did/src/methods/did-pkh.ts
@@ -103,17 +103,20 @@ export function caip10AccountIdFromDidPkhUri(
 /**
  * Create a did:pkh URI
  *
+ * @param chainId - The full CAIP-2 chain ID (e.g. `eip155:1`, `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`)
  * @param address - The address to create the did:pkh URI for
- * @param chainId - The full CAIP-2 chain ID (e.g. `eip155:1`, `solana`)
  * @returns The did:pkh URI
  *
  * @example
  * ```ts
- * const did = createDidPkhUri("0x1234567890123456789012345678901234567890", "eip155:1")
+ * const did = createDidPkhUri("eip155:1", "0x1234567890123456789012345678901234567890")
  * // did:pkh:eip155:1:0x1234567890123456789012345678901234567890
  *
- * const did = createDidPkhUri("FNoGHiv7DKPLXHfuhiEWpJ8qYitawGkuaYwfYkuvFk1P", "solana")
- * // did:pkh:solana:FNoGHiv7DKPLXHfuhiEWpJ8qYitawGkuaYwfYkuvFk1P
+ * const did = createDidPkhUri(
+ *   "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+ *   "FNoGHiv7DKPLXHfuhiEWpJ8qYitawGkuaYwfYkuvFk1P",
+ * )
+ * // did:pkh:solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:FNoGHiv7DKPLXHfuhiEWpJ8qYitawGkuaYwfYkuvFk1P
  * ```
  */
 export function createDidPkhUri(


### PR DESCRIPTION
## Summary
- Align `createDidPkhUri` JSDoc `@param` order and examples with the real `(chainId, address)` signature.
- Use a full Solana CAIP-2 chain ID in the example instead of bare `solana`.

## Testing
- Docs-only change; compared against `packages/did/README.md` and existing call sites.

## AI usage disclosure
Assisted by Cursor. I confirmed the signature/docs mismatch against README and runtime call sites before submitting.

Fixes #206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `createDidPkhUri` documentation to reflect the correct parameter order.
  * Clarified examples to use complete CAIP-2 chain identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->