### PR TITLE
fix(ack-id): require DID URIs in controllerClaimSchema

### DIFF
--- a/.changeset/ack-id-controller-claim-did-uri.md
+++ b/.changeset/ack-id-controller-claim-did-uri.md
@@ -1,0 +1,5 @@
+---
+"@agentcommercekit/ack-id": patch
+---
+
+Require `controllerClaimSchema` `id` and `controller` fields to be DID URIs in both Valibot and Zod, rejecting empty strings and other non-DID values at the schema boundary.

--- a/packages/ack-id/src/schemas/schemas.test.ts
+++ b/packages/ack-id/src/schemas/schemas.test.ts
@@ -1,0 +1,44 @@
+import * as v from "valibot"
+import { describe, expect, it } from "vitest"
+
+import { controllerClaimSchema as valibotControllerClaimSchema } from "./valibot"
+import { controllerClaimSchema as zodControllerClaimSchema } from "./zod"
+
+const validClaim = {
+  id: "did:web:agent.example.com",
+  controller: "did:web:controller.example.com",
+}
+
+describe("controllerClaimSchema", () => {
+  it("accepts DID URIs for id and controller", () => {
+    expect(v.safeParse(valibotControllerClaimSchema, validClaim).success).toBe(
+      true,
+    )
+    expect(zodControllerClaimSchema.safeParse(validClaim).success).toBe(true)
+  })
+
+  it("rejects empty id and controller strings", () => {
+    for (const input of [
+      { ...validClaim, id: "" },
+      { ...validClaim, controller: "" },
+      { id: "", controller: "" },
+    ]) {
+      expect(v.safeParse(valibotControllerClaimSchema, input).success).toBe(
+        false,
+      )
+      expect(zodControllerClaimSchema.safeParse(input).success).toBe(false)
+    }
+  })
+
+  it("rejects non-DID id and controller values", () => {
+    for (const input of [
+      { ...validClaim, id: "agent.example.com" },
+      { ...validClaim, controller: "not-a-did" },
+    ]) {
+      expect(v.safeParse(valibotControllerClaimSchema, input).success).toBe(
+        false,
+      )
+      expect(zodControllerClaimSchema.safeParse(input).success).toBe(false)
+    }
+  })
+})

--- a/packages/ack-id/src/schemas/valibot.ts
+++ b/packages/ack-id/src/schemas/valibot.ts
@@ -1,6 +1,7 @@
+import { didUriSchema } from "@agentcommercekit/did/schemas/valibot"
 import * as v from "valibot"
 
 export const controllerClaimSchema = v.object({
-  id: v.string(),
-  controller: v.string(),
+  id: didUriSchema,
+  controller: didUriSchema,
 })

--- a/packages/ack-id/src/schemas/zod.ts
+++ b/packages/ack-id/src/schemas/zod.ts
@@ -1,6 +1,7 @@
+import { didUriSchema } from "@agentcommercekit/did/schemas/zod"
 import * as z from "zod"
 
 export const controllerClaimSchema = z.object({
-  id: z.string(),
-  controller: z.string(),
+  id: didUriSchema,
+  controller: didUriSchema,
 })


### PR DESCRIPTION
## Summary
- Require `controllerClaimSchema` `id` and `controller` to be DID URIs in both Valibot and Zod.
- Rejects empty strings and non-DID values at the schema boundary, matching how `createControllerCredential` types these fields.
- Add schema parity tests.

## Testing
- `pnpm --filter @agentcommercekit/ack-id exec vitest run src/schemas/schemas.test.ts src/controller-claim-verifier.test.ts`

## AI usage disclosure
Assisted by Cursor. I reviewed the controller claim verifier and credential creator types, implemented the dual-schema change, and ran the focused tests myself.

Fixes #207