### PR TITLE
docs(ack-pay): fix invalid new BigInt() in README example

### DIFF
--- a/packages/ack-pay/README.md
+++ b/packages/ack-pay/README.md
@@ -31,7 +31,7 @@ const paymentRequest = {
   paymentOptions: [
     {
       id: "option-1",
-      amount: new BigInt(100_000_000).toString(), // 100 USDC
+      amount: BigInt(100_000_000).toString(), // 100 USDC
       decimals: 6,
       currency: "USDC",
       recipient: "did:web:payment.example.com",


### PR DESCRIPTION
## Summary
- The ack-pay README payment-request example used `new BigInt(...)`, which throws `TypeError: BigInt is not a constructor`.
- Switch to `BigInt(100_000_000).toString()` so the snippet is copy-paste runnable.

Docs-only. No open/closed PR or issue covers this.

## Testing
- Confirmed `new BigInt(100)` throws; `BigInt(100_000_000).toString()` → `"100000000"`.

## AI usage disclosure
Assisted by Cursor. I verified the runtime error and the corrected form before submitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the payment request example to use valid BigInt syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->