### PR TITLE
docs(caip): fix createCaip10AccountId JSDoc argument order

### DIFF
--- a/packages/caip/src/caips/caip-10.ts
+++ b/packages/caip/src/caips/caip-10.ts
@@ -30,8 +30,8 @@ export const caip10AccountIdRegex = new RegExp(`^${caip10AccountIdPattern}$`)
 /**
  * Create a CAIP-10 Account ID
  *
+ * @param chainId - The full CAIP-2 chain ID (e.g. `eip155:1`, `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`)
  * @param address - The address to create the CAIP-10 Account ID for
- * @param chainId - The CAIP-2 chain ID (e.g. `eip155:1`, `solana`) for this address
  * @returns The CAIP-10 Account ID
  */
 export function createCaip10AccountId(


### PR DESCRIPTION
## Summary
- Align `createCaip10AccountId` JSDoc `@param` order with the real `(chainId, address)` signature.
- Use a full Solana CAIP-2 chain ID in the example instead of bare `solana`.

Same class of docs mismatch as the merged `createDidPkhUri` fix (#209), but for CAIP-10. No existing open/closed PR covers this JSDoc.

## Testing
- Docs-only; compared against `packages/caip/README.md` and `caip-10.test.ts` call sites.

## AI usage disclosure
Assisted by Cursor. I confirmed the signature/docs mismatch against README and tests before submitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the `chainId` parameter documentation with complete CAIP-2 chain ID examples.
  - Reordered parameter descriptions for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->